### PR TITLE
Fix bug that rename may cause crash (issue #22)

### DIFF
--- a/Lib/src/be/ppareit/swiftp/server/CmdRNTO.java
+++ b/Lib/src/be/ppareit/swiftp/server/CmdRNTO.java
@@ -59,7 +59,7 @@ public class CmdRNTO extends FtpCmd implements Runnable {
             // be replaced with Files.move()
             File tmpFile = null;
             try {
-                tmpFile = File.createTempFile(fromFile.getName(), null,
+                tmpFile = File.createTempFile("temp_" + fromFile.getName(), null,
                         sessionThread.getWorkingDir());
                 if (fromFile.isDirectory()) {
                     String tmpFilePath = tmpFile.getPath();


### PR DESCRIPTION
When the file name is less than 3 characters, rename it will cause crash.
