### PR TITLE
Update app to add material theme to supported devices (Android Lollipop+)

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -38,6 +38,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         android:targetSdkVersion="21" />
 
     <application
+		android:theme="@style/AppTheme"
         android:icon="@drawable/launcher"
         android:label="@string/swiftp_name"
         android:name="be.ppareit.swiftp.FsApp"

--- a/free/AndroidManifest.xml
+++ b/free/AndroidManifest.xml
@@ -38,6 +38,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         android:targetSdkVersion="21" />
 
     <application
+        android:theme="@style/AppTheme"
         android:icon="@drawable/launcher"
         android:label="@string/swiftp_name"
         android:name="be.ppareit.swiftp.FsApp"

--- a/paid/AndroidManifest.xml
+++ b/paid/AndroidManifest.xml
@@ -35,7 +35,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
     <uses-sdk
         android:minSdkVersion="14"
-        android:targetSdkVersion="19" />
+        android:targetSdkVersion="21" />
 
     <application
         android:icon="@drawable/launcher"

--- a/paid/AndroidManifest.xml
+++ b/paid/AndroidManifest.xml
@@ -38,6 +38,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         android:targetSdkVersion="21" />
 
     <application
+        android:theme="@style/AppTheme"
         android:icon="@drawable/launcher"
         android:label="@string/swiftp_name"
         android:name="be.ppareit.swiftp.FsApp"

--- a/res/values-v21/strings.xml
+++ b/res/values-v21/strings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2011-2013 Pieter Pareit
+Copyright 2009 David Revell
+
+This file is part of SwiFTP.
+
+SwiFTP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SwiFTP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<resources>
+    <color name="primary_dark">#212121</color>
+    <color name="primary">#424242</color>
+
+</resources>

--- a/res/values-v21/styles.xml
+++ b/res/values-v21/styles.xml
@@ -1,0 +1,16 @@
+<resources>
+
+    <style name="AppBaseTheme" parent="android:Theme.Material">
+    </style>
+
+    <!-- Application theme. -->
+    <style name="AppTheme" parent="AppBaseTheme">
+        <item name="android:colorPrimary">@color/primary</item>
+	    <!--   darker variant for the status bar and contextual app bars -->
+	    <item name="android:colorPrimaryDark">@color/primary_dark</item>
+	    
+	    <item name="android:navigationBarColor">@color/primary_dark</item>
+	    <item name="android:windowBackground">@color/primary_dark</item>
+    </style>
+
+</resources>


### PR DESCRIPTION
I have added a theme for android sdk 21+ as well as fixed the target version of the paid version to be 21.  