### PR TITLE
Lint error fixed | FileNotFoundException added to fix compilation error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 25
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "be.ppareit.swiftp"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 28
         versionCode 21900
         versionName "2.19"
     }

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -214,8 +214,12 @@ public abstract class FileUtil {
             if (document == null) {
                 return false;
             }
-            if (DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(), target.getName()) != null) {
-                return true;
+            try {
+                if (DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(), target.getName()) != null) {
+                    return true;
+                }
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
             }
         }
 
@@ -255,8 +259,12 @@ public abstract class FileUtil {
             if (document == null) {
                 return false;
             }
-            if (DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(), target.getName()) != null) {
-                return true;
+            try {
+                if(DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(), target.getName()) != null) {
+                    return true;
+                }
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
             }
         }
 


### PR DESCRIPTION
It will be honor for me to show my work here.I was compiling swiftp today and found 2 errors while building.

**Brief Description of errors**

First one was a build error. In fact it was a lint error.This was there because the target sdk (25) was depreciated.Therefore i increased the target sdk version to latest 28 and also inceased build sdk to 28 (no need to download sdk 25 images to setup build environment).Trimmed log can be found in [LintError.zip](https://github.com/ppareit/swiftp/files/2580955/LintError.zip).

Second one was a compilation error.By analysing log i got to know that there is a undeclared exception in `FileUtil.java` which needs to be declared or thrown.Therefore to fix this error i added a try catch block to that code block.Trimmed log can be found [here](https://pastebin.com/AYcr4yZn).


