### PR TITLE
Set requestLegacyExternalStorage=true (Android API 29)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,6 +43,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         android:name="be.ppareit.swiftp.App"
         android:allowBackup="true"
         android:banner="@drawable/banner"
+        android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/launcher"
         android:label="@string/swiftp_name">
 


### PR DESCRIPTION
If `targetSdkVersion` is 29, then set `<application android:requestLegacyExternalStorage="true">`.

Otherwise, `File.listFiles()` returns null, causing `LIST` to fail