### PR TITLE
Drops password in plain text to public logcat. Comment for security. …

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
@@ -245,7 +245,8 @@ public class SessionThread extends Thread {
                 String line;
                 line = in.readLine(); // will accept \r\n or \n for terminator
                 if (line != null) {
-                    Cat.d("Received line from client: " + line);
+                    //Should normally stay commented. Dumps password into public logcat in plain text.
+                    //Cat.d("Received line from client: " + line);
                     FtpCmd.dispatchCommand(this, line);
                 } else {
                     Cat.i("readLine gave null, quitting");


### PR DESCRIPTION
…A reminder to comment it for release or a security fix should it not have been blocked for release.

Just throwing that your way at the moment as I'm not sure if you've thought about that or not. As if its dumping the password to logcat on production, its not a great idea. Better to be commented than to not be.