### PR TITLE
Scoped storage implementation of Android 11+ and also bump older vers…

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsSettings.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsSettings.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 
 import be.ppareit.swiftp.server.FtpUser;
+import be.ppareit.swiftp.utils.FileUtil;
 
 public class FsSettings {
 
@@ -110,6 +111,31 @@ public class FsSettings {
     }
 
     public static File getDefaultChrootDir() {
+        // Get the path from the app's MANAGE USERS chroot folder UI text field that the user will use during setup.
+        String subFix = null;
+        if (Util.useScopedStorage()) {
+            // The app's MANAGE USERS chroot folder UI selection cannot select the sd card at least on Android 11+.
+            //  The picker does all that's needed there so that use should be switched with ADVANCED SETTINGS >
+            //  WRITE EXTERNAL picker or just make it invisible when on A11+ ? Could also just pull open the same
+            //  picker on both with A11+ or something else. It also presents possible conflicts with the Uri path
+            //  eg "/storage/sd card/" verses "/sd card/Test/".
+            String s = FileUtil.cleanupUriStoragePath(FileUtil.getTreeUri());
+            if (s != null && !s.contains("primary:")) {
+                final String chroot = FileUtil.getSdCardBaseFolderScopedStorage();
+                // Need to return eg "/storage" for sd card and "/storage/emulated/0" for internal.
+                if (chroot != null && !chroot.isEmpty()) return new File(chroot);
+                // otherwise just get the other path from below.
+            } else if (s != null && s.contains("primary:")) {
+                // Fix for issue seen on Android 8.0:
+                // Had to implement over below as the below chroot is forced to
+                // getExternalStorageDirectory() when actual chroot may include further sub dirs.
+                subFix = s.replace("primary:", "");
+                // At the moment, have to do it below, as a StackOverflow is happening on the test device
+                // here with any additional code for an unknown reason.
+            }
+        }
+
+        // Original below incorrectly returns "/storage/emulated/0" for sd card with Android 11+
         File chrootDir;
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
             chrootDir = Environment.getExternalStorageDirectory();
@@ -123,6 +149,7 @@ public class FsSettings {
             // but this will probably not be what the user wants
             return App.getAppContext().getFilesDir();
         }
+        if (subFix != null) return new File(chrootDir, subFix);
         return chrootDir;
     }
 

--- a/app/src/main/java/be/ppareit/swiftp/Util.java
+++ b/app/src/main/java/be/ppareit/swiftp/Util.java
@@ -118,10 +118,8 @@ abstract public class Util {
      * Uses an override for when File fails to work during a test as the user sets up the app.
      * */
     public static boolean useScopedStorage() {
-        if (sp == null) {
-            sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
-            overrideSDKVer = sp.getBoolean("OverrideScopedStorageMinimum", false);
-        }
+        if (sp == null) sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+        overrideSDKVer = sp.getBoolean("OverrideScopedStorageMinimum", false);
         return Build.VERSION.SDK_INT >= 30 || overrideSDKVer;
     }
 

--- a/app/src/main/java/be/ppareit/swiftp/Util.java
+++ b/app/src/main/java/be/ppareit/swiftp/Util.java
@@ -21,6 +21,8 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 package be.ppareit.swiftp;
 
 import android.app.Activity;
+import android.content.SharedPreferences;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
@@ -34,6 +36,8 @@ import java.util.TimeZone;
 
 abstract public class Util {
     final static String TAG = Util.class.getSimpleName();
+    private static SharedPreferences sp = null;
+    private static boolean overrideSDKVer = false;
 
     public static byte byteOfInt(int value, int which) {
         int shift = which * 8;
@@ -107,5 +111,21 @@ abstract public class Util {
     public static Date parseDate(String time) throws ParseException {
         SimpleDateFormat df = createSimpleDateFormat();
         return df.parse(time);
+    }
+
+    /*
+     * Implemented mainly for Android 11+ where its forced but can work on earlier Android versions.
+     * Uses an override for when File fails to work during a test as the user sets up the app.
+     * */
+    public static boolean useScopedStorage() {
+        if (sp == null) {
+            sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+            overrideSDKVer = sp.getBoolean("OverrideScopedStorageMinimum", false);
+        }
+        return Build.VERSION.SDK_INT >= 30 || overrideSDKVer;
+    }
+
+    public static void reGetStorageOverride() {
+        sp = null;
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
@@ -318,7 +318,8 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
             File root = new File(a11Path);
             if (!root.canRead() || !root.canWrite()) {
                 SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
-                sp.edit().putBoolean("OverrideScopedStorageMinimum", true).apply();
+                // Fix: Use commit; override in next method using useScopedStorage() needs it.
+                sp.edit().putBoolean("OverrideScopedStorageMinimum", true).commit();
             }
         }
     }

--- a/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
@@ -3,10 +3,14 @@ package be.ppareit.swiftp.gui;
 
 import android.app.AlertDialog;
 import android.app.Fragment;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Environment;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -16,8 +20,10 @@ import android.widget.Toast;
 
 import java.io.File;
 
+import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.R;
+import be.ppareit.swiftp.Util;
 import be.ppareit.swiftp.server.FtpUser;
 
 public class UserEditFragment extends Fragment {
@@ -45,9 +51,19 @@ public class UserEditFragment extends Fragment {
         chroot.setOnFocusChangeListener((v, hasFocus) -> {
             if (!hasFocus)
                 return;
-            showFolderPicker(chroot);
+            if (Util.useScopedStorage()) {
+                alertUsersToScopedStorage();
+            } else {
+                showFolderPicker(chroot);
+            }
         });
-        chroot.setOnClickListener(view -> showFolderPicker(chroot));
+        chroot.setOnClickListener(v -> {
+            if (Util.useScopedStorage()) {
+                alertUsersToScopedStorage();
+            } else {
+                showFolderPicker(chroot);
+            }
+        });
 
         if (item != null) {
             username.setText(item.getUsername());
@@ -81,10 +97,15 @@ public class UserEditFragment extends Fragment {
         AlertDialog folderPicker = new FolderPickerDialogBuilder(getActivity(), startDir)
                 .setSelectedButton(R.string.select, path -> {
                     final File root = new File(path);
-                    if (!root.canRead()) {
-                        showToast(R.string.notice_cant_read_write);
-                    } else if (!root.canWrite()) {
-                        showToast(R.string.notice_cant_write);
+                    if (!root.canRead() || !root.canWrite()) {
+                        Log.e("pre", "using scoped...");
+                        alertUsersToScopedStorage();
+                    } else {
+                        Log.e("pre", "FILE CAN READ & WRITE...");
+                        // Disable the storage minimum override if eg internal use has rw capability over sd card.
+                        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+                        sp.edit().remove("OverrideScopedStorageMinimum").apply();
+                        Util.reGetStorageOverride();
                     }
                     chrootView.setText(path);
                 })
@@ -112,5 +133,13 @@ public class UserEditFragment extends Fragment {
 
     interface OnEditFinishedListener {
         void onEditActionFinished(FtpUser oldItem, FtpUser newItem);
+    }
+
+    // Android 11+ must use the other picker only. Alert users to go there.
+    // eg Android 8.0 sd card may be required also determined by check above.
+    private void alertUsersToScopedStorage() {
+        final String s = getString(R.string.advanced_settings_label) + " > " +
+                getString(R.string.writeExternalStorage_label);
+        Toast.makeText(App.getAppContext(), s, Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractListing.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractListing.java
@@ -28,10 +28,14 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 package be.ppareit.swiftp.server;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Comparator;
 
 import android.util.Log;
+
+import androidx.documentfile.provider.DocumentFile;
+
+import be.ppareit.swiftp.Util;
+import be.ppareit.swiftp.utils.FileUtil;
 
 public abstract class CmdAbstractListing extends FtpCmd {
     // TODO: .class.getSimpleName() from abstract class?
@@ -41,26 +45,74 @@ public abstract class CmdAbstractListing extends FtpCmd {
         super(sessionThread);
     }
 
-    abstract String makeLsString(File file);
+    abstract String makeLsString(FileUtil.Gen gen);
 
     // Creates a directory listing by finding the contents of the directory,
     // calling makeLsString on each file, and concatenating the results.
     // Returns an error string if failure, returns null on success. May be
     // called by CmdLIST or CmdNLST, since they each override makeLsString
     // in a different way.
-    public String listDirectory(StringBuilder response, File dir) {
-        if (!dir.isDirectory()) {
+    public String listDirectory(StringBuilder response, FileUtil.Gen dir) {
+        if (dir == null || !dir.isDirectory()) {
             return "500 Internal error, listDirectory on non-directory\r\n";
         }
         Log.d(TAG, "Listing directory: " + dir.toString());
 
+        final Object o = dir.getOb();
+        final boolean isScoped = Util.useScopedStorage() && o instanceof DocumentFile;
+        if (isScoped) return listEntriesScoped(response, (DocumentFile) o);
+        else return listEntriesScopedPre(response, (File) o);
+    }
+
+    private String listEntriesScoped(StringBuilder response, DocumentFile dir) {
+        DocumentFile[] entries;
+        // Get a listing of all files and directories in the path
+        try {
+            entries = dir.listFiles(); // about 2 seconds for 1,700 files
+        } catch (NullPointerException e) {
+            return "500 Couldn't list directory. Check config and mount status.\r\n";
+        }
+        // Removed sorting as its far too slow with DocumentFile and also not seeing a reason...
+        //  May also be negatively affecting File also at times.
+        //  Unknown what the original reason was for even using Arrays.sort() here anyway as
+        //  the client applications do their own sorting eg FileZilla has its own sort and is sorted
+        //  by name when it gets the list here without Arrays.sort().
+        //  Plus, FileZilla also times out and ends the listing at 20 seconds :)
+        //  And also, sorting first using File then using DocumentFile.fromFile results in "File://"
+        //  Uri which will only cause problems as it doesn't hold full use.
+        final int cpuThreadCount = Runtime.getRuntime().availableProcessors();
+        if (entries.length < cpuThreadCount || cpuThreadCount == 1) { // Absolute minimum for threaded
+            buildResponseOldStyle(response, entries);
+        } else {
+            // On Android 11 with DocumentFile which is much slower than File...
+            // Seeing about 2,214 files max at 8 threads within FileZilla's 20 second delay timeout axe
+            // give or take depending on device core/thread amount and CPU performance. Plus ~2 second
+            // leftover. So, can do about 123 files per second with current code.
+            // Total backup time test of threads w/near similar backup execution & 600+ files to list:
+            // cpu #1: 3 min 59 seconds
+            // cpu #2: 2 min 58 seconds
+            // cpu #8: 1 min 53 seconds
+            // 2 minutes less with device of 8 CPU threads when using buildResponseThreaded().
+            // Android 6 with File...
+            // 5,161 files being listed:
+            // Old non-threaded time: 9 seconds
+            // New threaded time: < 1 second
+            buildResponseThreaded(response, entries, cpuThreadCount);
+        }
+
+        return null;
+    }
+
+    private String listEntriesScopedPre(StringBuilder response, File dir) {
         // Get a listing of all files and directories in the path
         File[] entries = dir.listFiles();
         if (entries == null) {
             return "500 Couldn't list directory. Check config and mount status.\r\n";
         }
         Log.d(TAG, "Dir len " + entries.length);
-        try {
+
+        // Commented for performance. Not seeing any negative effect from not using. Client should do this anyway.
+/*        try {
             Arrays.sort(entries, listingComparator);
         } catch (Exception e) {
             // once got a FC on this, seems it is possible to have a dir that
@@ -69,13 +121,154 @@ public abstract class CmdAbstractListing extends FtpCmd {
             // play for sure, and get back the entries
             entries = dir.listFiles();
         }
-        for (File entry : entries) {
-            String curLine = makeLsString(entry);
+
+        if (entries == null) {
+            return "500 Couldn't list directory. Check config and mount status.\r\n";
+        }*/
+
+        final int cpuThreadCount = Runtime.getRuntime().availableProcessors();
+        if (entries.length < cpuThreadCount) { // use cpu count as an absolute minimum
+            buildResponseOldStyle(response, entries);
+        } else {
+            buildResponseThreaded(response, entries, cpuThreadCount);
+        }
+
+        return null;
+    }
+
+    private void buildResponseOldStyle(StringBuilder response, DocumentFile[] entries) {
+        for (DocumentFile entry : entries) {
+            String curLine = makeLsString(new FileUtil.Gen(entry));
             if (curLine != null) {
                 response.append(curLine);
             }
         }
-        return null;
+    }
+
+    private void buildResponseOldStyle(StringBuilder response, File[] entries) {
+        for (File entry : entries) {
+            String curLine = makeLsString(new FileUtil.Gen(entry));
+            if (curLine != null) {
+                response.append(curLine);
+            }
+        }
+    }
+
+    private void buildResponseThreaded(StringBuilder response, DocumentFile[] entries, final int cpuThreadCount) {
+        // Prep for threading per core/thread count
+        // More than 2 threads should only help more as the entries count increase
+        Thread[] threads = new Thread[cpuThreadCount];
+        StringBuilder[] responses = new StringBuilder[cpuThreadCount];
+        final int totalCount = entries.length;
+        final int splitCount = totalCount / cpuThreadCount;
+        int[] startLoc = new int[cpuThreadCount];
+        int[] endLoc = new int[cpuThreadCount]; // eg 270 is total count 271 since starting at 0
+        for (int i = 0; i < cpuThreadCount; i++) {
+            startLoc[i] = splitCount * i;
+            if (i > 0) startLoc[i]++; // add one so they don't start where the other ends
+            endLoc[i] = i == 0 ? splitCount : splitCount * (i + 1);
+            if (i == cpuThreadCount - 1) {
+                if (endLoc[i] != totalCount - 1)
+                    endLoc[i] = totalCount - 1; // sometimes off
+            }
+            responses[i] = new StringBuilder();
+        }
+
+        // Split off onto the cores/threads of the device
+        for (int i = 0; i < cpuThreadCount; i++) {
+            threads[i] = dynamicThreadSplitter(entries, responses, i, startLoc, endLoc);
+            threads[i].setPriority(Thread.MIN_PRIORITY);
+            threads[i].start();
+        }
+
+        // Need to wait until all are finished starting with first running to last running
+        dynamicThreadJoiner(threads);
+
+        // Need to include results from first to last to keep them in the proper order
+        response.append(dynamicResponseJoiner(responses));
+    }
+
+    private void buildResponseThreaded(StringBuilder response, File[] entries, final int cpuThreadCount) {
+        // Prep for threading per core/thread count
+        // More than 2 threads should only help more as the entries count increase
+        Thread[] threads = new Thread[cpuThreadCount];
+        StringBuilder[] responses = new StringBuilder[cpuThreadCount];
+        final int totalCount = entries.length;
+        final int splitCount = totalCount / cpuThreadCount;
+        int[] startLoc = new int[cpuThreadCount];
+        int[] endLoc = new int[cpuThreadCount]; // eg 270 is total count 271 since starting at 0
+        for (int i = 0; i < cpuThreadCount; i++) {
+            startLoc[i] = splitCount * i;
+            if (i > 0) startLoc[i]++; // add one so they don't start where the other ends
+            endLoc[i] = i == 0 ? splitCount : splitCount * (i + 1);
+            if (i == cpuThreadCount - 1) {
+                if (endLoc[i] != totalCount - 1)
+                    endLoc[i] = totalCount - 1; // sometimes off
+            }
+            responses[i] = new StringBuilder();
+        }
+
+        // Split off onto the cores/threads of the device for more performance here
+        for (int i = 0; i < cpuThreadCount; i++) {
+            threads[i] = dynamicThreadSplitter(entries, responses, i, startLoc, endLoc);
+            threads[i].start();
+        }
+
+        // Need to wait until all are finished starting with first running to last running
+        dynamicThreadJoiner(threads);
+
+        // Need to include results from first to last to keep them in the proper order
+        response.append(dynamicResponseJoiner(responses));
+    }
+
+    /*
+     * Eg if device has 3 threads and there are 180 entries (aka files):
+     * 60 * 3 = 180
+     * So 0-60 thread 1, 61-120 thread 2, 121-180 thread 3 (push down 1 w/array)
+     * (or another example eg 271 / 2 = 0-135 for thread 1 and 136-270 for thread 2)
+     * */
+    private Thread dynamicThreadSplitter(DocumentFile[] entries, StringBuilder[] response, final int loc,
+                                         int[] startLoc, int[] endLoc) {
+        return new Thread(() -> {
+            for (int i = startLoc[loc]; i <= endLoc[loc]; i++) { // Needs to start at next of prev thread
+                String curLine = makeLsString(new FileUtil.Gen(entries[i]));
+                if (curLine != null) {
+                    response[loc].append(curLine);
+                }
+            }
+        });
+    }
+
+    private Thread dynamicThreadSplitter(File[] entries, StringBuilder[] response, final int loc, int[] startLoc,
+                                         int[] endLoc) {
+        return new Thread(() -> {
+            for (int i = startLoc[loc]; i <= endLoc[loc]; i++) { // Needs to start at next of prev thread
+                String curLine = makeLsString(new FileUtil.Gen(entries[i]));
+                if (curLine != null) {
+                    response[loc].append(curLine);
+                }
+            }
+        });
+    }
+
+    private void dynamicThreadJoiner(Thread[] t) {
+        for (Thread thread : t) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (NullPointerException e) {
+                // just continue marching on
+            }
+        }
+    }
+
+    private StringBuilder dynamicResponseJoiner(StringBuilder[] sb) {
+        StringBuilder result = new StringBuilder();
+        for (StringBuilder each : sb) {
+            result.append(each);
+        }
+        return result;
     }
 
     // Send the directory listing over the data socket. Used by CmdLIST and CmdNLST.

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractStore.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractStore.java
@@ -49,7 +49,7 @@ abstract public class CmdAbstractStore extends FtpCmd {
         Cat.d("STOR/APPE executing with append = " + append);
 
         File storeFile = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                sessionThread.getWorkingDir(), param, false);
+                sessionThread.getWorkingDir(), param);
         DocumentFile docStoreFile = null;
         String errString = null;
         FileOutputStream out = null;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdCWD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdCWD.java
@@ -41,7 +41,8 @@ public class CmdCWD extends FtpCmd implements Runnable {
         File newDir;
         String errString = null;
         mainblock: {
-            newDir = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+            newDir = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, true);
 
             // Ensure the new path does not violate the chroot restriction
             if (violatesChroot(newDir)) {

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdCWD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdCWD.java
@@ -42,7 +42,7 @@ public class CmdCWD extends FtpCmd implements Runnable {
         String errString = null;
         mainblock: {
             newDir = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, true);
+                    sessionThread.getWorkingDir(), param);
 
             // Ensure the new path does not violate the chroot restriction
             if (violatesChroot(newDir)) {

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdDELE.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdDELE.java
@@ -45,7 +45,7 @@ public class CmdDELE extends FtpCmd implements Runnable {
         Log.d(TAG, "DELE executing");
         String param = getParameter(input);
         File storeFile = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                sessionThread.getWorkingDir(), param, false);
+                sessionThread.getWorkingDir(), param);
 
         if (Util.useScopedStorage()) {
             String clientPath;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdDELE.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdDELE.java
@@ -48,8 +48,13 @@ public class CmdDELE extends FtpCmd implements Runnable {
                 sessionThread.getWorkingDir(), param, false);
 
         if (Util.useScopedStorage()) {
-            final String clientPath = storeFile.getPath().substring(0, storeFile.getPath()
-                    .lastIndexOf(File.separator));
+            String clientPath;
+            final String sfPath = storeFile.getPath();
+            if (sfPath.contains(File.separator)) {
+                clientPath = sfPath.substring(0, sfPath.lastIndexOf(File.separator));
+            } else {
+                clientPath = sfPath;
+            }
             DocumentFile docStoreFile = FileUtil.getDocumentFileWithParamScopedStorage(File.separator +
                     param, null, clientPath);
             tryToDelete(new FileUtil.Gen(docStoreFile), clientPath);

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdHASH.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdHASH.java
@@ -1,7 +1,5 @@
 package be.ppareit.swiftp.server;
 
-import android.util.Log;
-
 import net.vrallev.android.cat.Cat;
 
 import java.io.File;
@@ -35,7 +33,7 @@ public class CmdHASH extends FtpCmd implements Runnable {
         mainblock:
         {
             fileToHash = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
             if (violatesChroot(fileToHash)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdHASH.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdHASH.java
@@ -34,7 +34,8 @@ public class CmdHASH extends FtpCmd implements Runnable {
 
         mainblock:
         {
-            fileToHash = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+            fileToHash = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, false);
             if (violatesChroot(fileToHash)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMDTM.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMDTM.java
@@ -20,10 +20,6 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 package be.ppareit.swiftp.server;
 
 import java.io.File;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
-import java.util.TimeZone;
 
 import be.ppareit.swiftp.Util;
 import android.util.Log;
@@ -46,7 +42,7 @@ public class CmdMDTM extends FtpCmd implements Runnable {
         Log.d(TAG, "run: MDTM executing, input: " + mInput);
         String param = getParameter(mInput);
         File file = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                sessionThread.getWorkingDir(), param, false);
+                sessionThread.getWorkingDir(), param);
 
         if (file.exists()) {
             long lastModified = file.lastModified();

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMDTM.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMDTM.java
@@ -45,7 +45,8 @@ public class CmdMDTM extends FtpCmd implements Runnable {
     public void run() {
         Log.d(TAG, "run: MDTM executing, input: " + mInput);
         String param = getParameter(mInput);
-        File file = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+        File file = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                sessionThread.getWorkingDir(), param, false);
 
         if (file.exists()) {
             long lastModified = file.lastModified();

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMFMT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMFMT.java
@@ -28,8 +28,6 @@ import java.util.TimeZone;
 
 import be.ppareit.swiftp.Util;
 
-import android.util.Log;
-
 import net.vrallev.android.cat.Cat;
 
 /**
@@ -75,7 +73,7 @@ public class CmdMFMT extends FtpCmd implements Runnable {
         }
 
         File file = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                sessionThread.getWorkingDir(), pathName, false);
+                sessionThread.getWorkingDir(), pathName);
 
         if (!file.exists()) {
             sessionThread.writeString("550 file does not exist on server\r\n");

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMFMT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMFMT.java
@@ -75,7 +75,7 @@ public class CmdMFMT extends FtpCmd implements Runnable {
         }
 
         File file = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                sessionThread.getWorkingDir(), pathName);
+                sessionThread.getWorkingDir(), pathName, false);
 
         if (!file.exists()) {
             sessionThread.writeString("550 file does not exist on server\r\n");

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMKD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMKD.java
@@ -50,7 +50,8 @@ public class CmdMKD extends FtpCmd implements Runnable {
                 errString = "550 Invalid name\r\n";
                 break mainblock;
             }
-            toCreate = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+            toCreate = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, true);
             if (violatesChroot(toCreate)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMKD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMKD.java
@@ -51,7 +51,7 @@ public class CmdMKD extends FtpCmd implements Runnable {
                 break mainblock;
             }
             toCreate = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, true);
+                    sessionThread.getWorkingDir(), param);
             if (violatesChroot(toCreate)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdMLST.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdMLST.java
@@ -48,7 +48,7 @@ public class CmdMLST extends FtpCmd implements Runnable {
             param = "/";
         }else{
             fileToFormat = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
         }
 
         if (fileToFormat.exists()) {

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdNLST.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdNLST.java
@@ -29,6 +29,7 @@ package be.ppareit.swiftp.server;
 import java.io.File;
 
 import android.util.Log;
+import be.ppareit.swiftp.utils.FileUtil;
 
 public class CmdNLST extends CmdAbstractListing implements Runnable {
     private static final String TAG = CmdNLST.class.getSimpleName();
@@ -75,13 +76,14 @@ public class CmdNLST extends CmdAbstractListing implements Runnable {
             String listing;
             if (fileToList.isDirectory()) {
                 StringBuilder response = new StringBuilder();
-                errString = listDirectory(response, fileToList);
+                FileUtil.Gen gen = FileUtil.createGenFromFile(fileToList);
+                errString = listDirectory(response, gen);
                 if (errString != null) {
                     break mainblock;
                 }
                 listing = response.toString();
             } else {
-                listing = makeLsString(fileToList);
+                listing = makeLsString(new FileUtil.Gen(fileToList));
                 if (listing == null) {
                     errString = "450 Couldn't list that file\r\n";
                     break mainblock;
@@ -104,7 +106,7 @@ public class CmdNLST extends CmdAbstractListing implements Runnable {
     }
 
     @Override
-    protected String makeLsString(File file) {
+    protected String makeLsString(FileUtil.Gen file) {
         if (!file.exists()) {
             Log.i(TAG, "makeLsString had nonexistent file");
             return null;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPWD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPWD.java
@@ -52,25 +52,12 @@ public class CmdPWD extends FtpCmd implements Runnable {
         try {
             String currentDir = sessionThread.getWorkingDir().getCanonicalPath();
             File chrootDir = sessionThread.getChrootDir();
-            if (Util.useScopedStorage()) {
-                Uri uri = FileUtil.getFullCWDUri("", currentDir);
-                DocumentFile df = null;
-                if (uri != null) df = FileUtil.getDocumentFileFromUri(uri);
-                final String path = FileUtil.getScopedClientPath(currentDir, null, null);
-                if (df != null) currentDir = FileUtil.getUriStoragePathFullFromDocumentFile(df, path);
-                if (chrootDir != null) {
-                    final String chroot = chrootDir.getPath();
-                    // Send back path as "/" instead of as chroot
-                    if (currentDir != null && currentDir.equals(chroot)) currentDir = "/";
-                }
-            } else {
-                if (chrootDir != null) {
-                    currentDir = currentDir.substring(chrootDir.getCanonicalPath().length());
-                }
+            if (chrootDir != null) {
+                currentDir = currentDir.substring(chrootDir.getCanonicalPath().length());
             }
             // The root directory requires special handling to restore its
             // leading slash
-            if (currentDir == null || currentDir.length() == 0) {
+            if (currentDir.length() == 0) {
                 currentDir = "/";
             }
             sessionThread.writeString("257 \"" + currentDir + "\"\r\n");

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPWD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPWD.java
@@ -51,14 +51,19 @@ public class CmdPWD extends FtpCmd implements Runnable {
         // user-visible path (inside the chroot directory).
         try {
             String currentDir = sessionThread.getWorkingDir().getCanonicalPath();
+            File chrootDir = sessionThread.getChrootDir();
             if (Util.useScopedStorage()) {
                 Uri uri = FileUtil.getFullCWDUri("", currentDir);
                 DocumentFile df = null;
                 if (uri != null) df = FileUtil.getDocumentFileFromUri(uri);
                 final String path = FileUtil.getScopedClientPath(currentDir, null, null);
                 if (df != null) currentDir = FileUtil.getUriStoragePathFullFromDocumentFile(df, path);
+                if (chrootDir != null) {
+                    final String chroot = chrootDir.getPath();
+                    // Send back path as "/" instead of as chroot
+                    if (currentDir != null && currentDir.equals(chroot)) currentDir = "/";
+                }
             } else {
-                File chrootDir = sessionThread.getChrootDir();
                 if (chrootDir != null) {
                     currentDir = currentDir.substring(chrootDir.getCanonicalPath().length());
                 }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
@@ -59,7 +59,13 @@ public class CmdRETR extends FtpCmd implements Runnable {
 
             DocumentFile docFileToRetr = null;
             if (Util.useScopedStorage()) {
-                final String clientPath = fileToRetr.getPath().substring(0, fileToRetr.getPath().lastIndexOf(File.separator));
+                String clientPath;
+                final String ftrPath = fileToRetr.getPath();
+                if (ftrPath.contains(File.separator)) {
+                    clientPath = ftrPath.substring(0, ftrPath.lastIndexOf(File.separator));
+                } else {
+                    clientPath = ftrPath;
+                }
                 docFileToRetr = FileUtil.getDocumentFileWithParamScopedStorage(param, null, clientPath);
                 if (docFileToRetr == null) {
                     errString = "550 File does not exist\r\n";

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
@@ -19,7 +19,9 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
 package be.ppareit.swiftp.server;
 
-import android.util.Log;
+import android.net.Uri;
+
+import androidx.documentfile.provider.DocumentFile;
 
 import net.vrallev.android.cat.Cat;
 
@@ -27,6 +29,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+
+import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.Util;
+import be.ppareit.swiftp.utils.FileUtil;
 
 public class CmdRETR extends FtpCmd implements Runnable {
 
@@ -46,27 +53,35 @@ public class CmdRETR extends FtpCmd implements Runnable {
 
         mainblock:
         {
-            fileToRetr = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
-            if (violatesChroot(fileToRetr)) {
-                errString = "550 Invalid name or chroot violation\r\n";
-                break mainblock;
-            } else if (fileToRetr.isDirectory()) {
-                Cat.d("Ignoring RETR for directory");
-                errString = "550 Can't RETR a directory\r\n";
-                break mainblock;
-            } else if (!fileToRetr.exists()) {
-                Cat.d("Can't RETR nonexistent file: " + fileToRetr.getAbsolutePath());
-                errString = "550 File does not exist\r\n";
-                break mainblock;
-            } else if (!fileToRetr.canRead()) {
-                Cat.i("Failed RETR permission (canRead() is false)");
-                errString = "550 No read permissions\r\n";
-                break mainblock;
+            fileToRetr = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, false);
+            Uri uri;
+
+            DocumentFile docFileToRetr = null;
+            if (Util.useScopedStorage()) {
+                final String clientPath = fileToRetr.getPath().substring(0, fileToRetr.getPath().lastIndexOf(File.separator));
+                docFileToRetr = FileUtil.getDocumentFileWithParamScopedStorage(param, null, clientPath);
+                if (docFileToRetr == null) {
+                    errString = "550 File does not exist\r\n";
+                    break mainblock;
+                }
             }
 
+            FileUtil.Gen gen;
+            if (docFileToRetr != null) gen = FileUtil.convertDocumentFileToGen(docFileToRetr);
+            else gen = FileUtil.convertFileToGen(fileToRetr);
+            if (validate(gen, param) != null) break mainblock;
+
             FileInputStream in = null;
+            InputStream is = null;
             try {
-                in = new FileInputStream(fileToRetr);
+                if (Util.useScopedStorage()) {
+                    if (docFileToRetr == null) break mainblock;
+                    uri = docFileToRetr.getUri();
+                    is = App.getAppContext().getContentResolver().openInputStream(uri);
+                } else {
+                    in = new FileInputStream(fileToRetr);
+                }
                 byte[] buffer = new byte[SessionThread.DATA_CHUNK_SIZE];
                 int bytesRead;
                 if (sessionThread.openDataSocket()) {
@@ -80,7 +95,8 @@ public class CmdRETR extends FtpCmd implements Runnable {
                 if (sessionThread.isBinaryMode()) { // RANG is supported only in binary mode.
                     Cat.d("Transferring in binary mode");
                     long offset = 0L;
-                    long endPosition = fileToRetr.length() - 1;
+                    long endPosition = (Util.useScopedStorage() ? docFileToRetr.length() - 1
+                            : fileToRetr.length() - 1);
                     if (sessionThread.offset >= 0) {
                         offset = sessionThread.offset;
                         if (sessionThread.endPosition >= offset) {
@@ -90,8 +106,9 @@ public class CmdRETR extends FtpCmd implements Runnable {
                     }
                     // This is not a range but length (Range 0-0 would still read 0th byte), so +1
                     long bytesToRead = endPosition - offset + 1;
-                    in.skip(offset);
-                    while ((bytesRead = in.read(buffer)) != -1) {
+                    if (Util.useScopedStorage()) is.skip(offset);
+                    else in.skip(offset);
+                    while ((bytesRead = (Util.useScopedStorage() ? is.read(buffer) : in.read(buffer))) != -1) {
                         boolean success;
                         if (bytesRead > bytesToRead) {
                             success = sessionThread.sendViaDataSocket(buffer, 0, (int) bytesToRead);
@@ -115,7 +132,7 @@ public class CmdRETR extends FtpCmd implements Runnable {
                     }
                     // We have to convert all solitary \n to \r\n
                     boolean lastBufEndedWithCR = false;
-                    while ((bytesRead = in.read(buffer)) != -1) {
+                    while ((bytesRead = (Util.useScopedStorage() ? is.read(buffer) : in.read(buffer))) != -1) {
                         int startPos = 0, endPos = 0;
                         byte[] crnBuf = {'\r', '\n'};
                         for (endPos = 0; endPos < bytesRead; endPos++) {
@@ -159,6 +176,8 @@ public class CmdRETR extends FtpCmd implements Runnable {
                 try {
                     if (in != null)
                         in.close();
+                    if (is != null)
+                        is.close();
                 } catch (IOException ignored) {
                 }
             }
@@ -170,5 +189,41 @@ public class CmdRETR extends FtpCmd implements Runnable {
             sessionThread.writeString("226 Transmission finished\r\n");
         }
         Cat.d("RETR done");
+    }
+
+    private String validate(FileUtil.Gen fileToRetr, String param) {
+        String errString = null;
+        if (fileToRetr == null) {
+            errString = "550 Invalid name or chroot violation\r\n";
+            return errString;
+        }
+
+        final boolean isDocumentFile = fileToRetr.getOb() instanceof DocumentFile;
+        final boolean isFile = !isDocumentFile;
+
+        String clientPath;
+        String path = null;
+        if (isDocumentFile) {
+            clientPath = param;
+            if (!param.contains(File.separator)) clientPath = "";
+            else if (!param.endsWith(File.separator)) clientPath = param.substring(0, param
+                    .lastIndexOf(File.separator));
+            path = FileUtil.getScopedClientPath(clientPath, null, null);
+        }
+        if ((isDocumentFile && violatesChroot((DocumentFile) fileToRetr.getOb(), path))
+                || (isFile && violatesChroot((File) fileToRetr.getOb()))) {
+            errString = "550 Invalid name or chroot violation\r\n";
+        } else if (fileToRetr.isDirectory()) {
+            Cat.d("Ignoring RETR for directory");
+            errString = "550 Can't RETR a directory\r\n";
+        } else if (!fileToRetr.exists()) {
+            if (isDocumentFile) Cat.d("Can't RETR nonexistent file: " + fileToRetr.getName());
+            else Cat.d("Can't RETR nonexistent file: " + ((File)fileToRetr.getOb()).getAbsolutePath());
+            errString = "550 File does not exist\r\n";
+        } else if (!fileToRetr.canRead()) {
+            Cat.i("Failed RETR permission (canRead() is false)");
+            errString = "550 No read permissions\r\n";
+        }
+        return errString;
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
@@ -54,7 +54,7 @@ public class CmdRETR extends FtpCmd implements Runnable {
         mainblock:
         {
             fileToRetr = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
             Uri uri;
 
             DocumentFile docFileToRetr = null;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRMD.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRMD.java
@@ -91,7 +91,7 @@ public class CmdRMD extends FtpCmd implements Runnable {
                 break mainblock;
             }
             toRemove = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
             if (violatesChroot(toRemove)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRNFR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRNFR.java
@@ -21,8 +21,6 @@ package be.ppareit.swiftp.server;
 
 import java.io.File;
 
-import android.util.Log;
-
 import net.vrallev.android.cat.Cat;
 
 /**
@@ -49,7 +47,7 @@ public class CmdRNFR extends FtpCmd implements Runnable {
         mainblock:
         {
             file = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
             if (violatesChroot(file)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRNFR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRNFR.java
@@ -48,7 +48,8 @@ public class CmdRNFR extends FtpCmd implements Runnable {
         File file = null;
         mainblock:
         {
-            file = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+            file = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, false);
             if (violatesChroot(file)) {
                 errString = "550 Invalid name or chroot violation\r\n";
                 break mainblock;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRNTO.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRNTO.java
@@ -54,7 +54,8 @@ public class CmdRNTO extends FtpCmd implements Runnable {
         File toFile = null;
         mainblock:
         {
-            toFile = inputPathToChrootedFile(sessionThread.getChrootDir(), sessionThread.getWorkingDir(), param);
+            toFile = inputPathToChrootedFile(sessionThread.getChrootDir(),
+                    sessionThread.getWorkingDir(), param, false);
             Cat.i("RNTO to file: " + toFile.getPath());
             if (violatesChroot(toFile)) {
                 errString = "550 Invalid name or chroot violation\r\n";

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRNTO.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRNTO.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 
 import android.os.Build;
-import android.util.Log;
 
 import net.vrallev.android.cat.Cat;
 
@@ -55,7 +54,7 @@ public class CmdRNTO extends FtpCmd implements Runnable {
         mainblock:
         {
             toFile = inputPathToChrootedFile(sessionThread.getChrootDir(),
-                    sessionThread.getWorkingDir(), param, false);
+                    sessionThread.getWorkingDir(), param);
             Cat.i("RNTO to file: " + toFile.getPath());
             if (violatesChroot(toFile)) {
                 errString = "550 Invalid name or chroot violation\r\n";

--- a/app/src/main/java/be/ppareit/swiftp/server/FtpCmd.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/FtpCmd.java
@@ -223,6 +223,8 @@ public abstract class FtpCmd implements Runnable {
                 // entire path needed. And then sometimes it doesn't have the entire path lol :)
                 if (param.contains(tree)) {
                     return new File(param);
+                } else if (param.equals(File.separator)) {
+                    return new File(tree); // Fix an occasion where it does not return to root
                 }
             }
             String mPath = "";

--- a/app/src/main/java/be/ppareit/swiftp/server/FtpCmd.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/FtpCmd.java
@@ -19,7 +19,6 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
 package be.ppareit.swiftp.server;
 
-import android.net.Uri;
 import android.util.Log;
 
 import androidx.documentfile.provider.DocumentFile;
@@ -27,7 +26,6 @@ import androidx.documentfile.provider.DocumentFile;
 import java.io.File;
 import java.lang.reflect.Constructor;
 
-import be.ppareit.swiftp.Util;
 import be.ppareit.swiftp.utils.FileUtil;
 
 public abstract class FtpCmd implements Runnable {
@@ -189,100 +187,7 @@ public abstract class FtpCmd implements Runnable {
         return getParameter(input, false);
     }
 
-    public static File inputPathToChrootedFile(final File chrootDir, final File existingPrefix,
-                                               String param, final boolean isDirOnly) {
-        if (Util.useScopedStorage()) {
-            // NEW WAY
-            // Chroot is *1 tree & including eg *2 "/storage" that the tree doesn't contain.
-            // *3 The rest is provided by the client.
-            // *4 The param when with file is with *3 so we need to remove path from param when it is.
-            // *5 All that's left is to tack on the client provided path to the end of the tree.
-            // There are multiple conflicting oddities that happen and are dealt with here.
-            if (isDirOnly && !param.startsWith(File.separator)) param = File.separator + param;
-            // May be empty at times and param will instead have it.
-            String sessionClientPath = FileUtil.getScopedClientPath(param, existingPrefix, null);
-            // Get the full chroot path including storage.
-            Uri uri = FileUtil.getTreeUri();
-            DocumentFile df = FileUtil.getDocumentFileFromUri(uri);
-            final String tree = FileUtil.getUriStoragePathFullFromDocumentFile(df, "");
-            if (tree == null) return new File(""); // That's bad. Make following checks fail.
-            // Deal with param and client specified paths.
-            String paramClientPath = "";
-            if (!isDirOnly && param.contains(File.separator)) {
-                final int lastSlash = param.lastIndexOf(File.separator);
-                paramClientPath = param.substring(0, lastSlash);
-                // Can't have it in there with the new code. That's a conflict!
-                param = param.substring(lastSlash + 1);
-                if (!paramClientPath.startsWith(File.separator)) {
-                    // Keep it the same to avoid problems.
-                    paramClientPath = File.separator + paramClientPath;
-                }
-            } else if (isDirOnly && param.contains(File.separator)) {
-                // To make things worse, the param can also be a full path such as in FileZilla and
-                // using its tree to jump randomly anywhere. Here, the param already contains the
-                // entire path needed. And then sometimes it doesn't have the entire path lol :)
-                if (param.contains(tree)) {
-                    return new File(param);
-                } else if (param.equals(File.separator)) {
-                    return new File(tree); // Fix an occasion where it does not return to root
-                }
-            }
-            String mPath = "";
-            // To make it worse, param can be dir and have no file and no slash lol. So...
-            // added isDirOnly in order to know what the calling method is working on as that can tell us.
-            if (isDirOnly) {
-                if (!sessionClientPath.isEmpty() && !sessionClientPath.equals(param)) {
-                    // Varoious fixes and checks of random ways it can do as seen on one device and internal
-                    if (param.startsWith(File.separator) && !tree.startsWith(File.separator)) {
-                        param = param.replaceFirst(File.separator, "");
-                    } else if (!param.startsWith(File.separator) && tree.startsWith(File.separator)) {
-                        param = File.separator + param;
-                    }
-                    if (param.endsWith(File.separator) && !tree.endsWith(File.separator)) {
-                        param = param.substring(0, param.length() - 1);
-                    } else if (!param.endsWith(File.separator) && tree.endsWith(File.separator)) {
-                        param += File.separator;
-                    }
-                    if (!param.equals(tree)) {
-                        mPath = sessionClientPath + File.separator + param;
-                    }
-                } else {
-                    mPath = param;
-                }
-            } else {
-                if (!sessionClientPath.isEmpty() && paramClientPath.isEmpty())
-                    mPath = sessionClientPath;
-                else if (sessionClientPath.isEmpty() && !paramClientPath.isEmpty())
-                    mPath = paramClientPath;
-                else {
-                    if (sessionClientPath.equals(paramClientPath)) mPath = sessionClientPath;
-                    else mPath = paramClientPath;
-                }
-            }
-            // Various checks and fixes as to ways it could go as seen on one device and internal
-            if (!mPath.startsWith(File.separator) && !tree.endsWith(File.separator)) {
-                mPath = File.separator + mPath;
-            } else if (mPath.startsWith(File.separator) && tree.endsWith(File.separator)) {
-                mPath = mPath.replaceFirst(File.separator, "");
-            }
-            // Finally get the full current path
-            String path = "";
-            if (!mPath.contains(tree)) path = tree + mPath;
-            // Let's end this.
-            if (!isDirOnly){
-                return new File(path, param);
-            }
-            if (sessionClientPath.equals(param)) {
-                final String doubleVision = sessionClientPath + param;
-                if (!path.endsWith(doubleVision)) {
-                    // Correct double vision; permutation fix
-                    return new File(path, param);
-                }
-            }
-            // Another possible end
-            return new File(path);
-        }
-        // OLD WAY (with issues and not compatible with the new way.)
+    public static File inputPathToChrootedFile(final File chrootDir, final File existingPrefix, String param) {
         try {
             if (param.charAt(0) == '/') {
                 // The STOR contained an absolute path

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -735,9 +735,13 @@ public abstract class FileUtil {
 
         Uri treeUri = null;
         if (as != null) treeUri = Uri.parse(as);
-        if (treeUri == null) {
-            return null;
+        if (Util.useScopedStorage() && treeUri == null) {
+            // Fix Android 8.0 sd card having null with FsSettings.getExternalStorageUri()
+            // The rest works fine after this
+            treeUri = getTreeUri();
         }
+        if (treeUri == null) return null;
+
         if (file.exists()) {
             Uri documentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, DocumentsContract.getTreeDocumentId(treeUri) + relativePath);
             DocumentFile document = DocumentFile.fromSingleUri(context, documentUri);

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -967,7 +967,15 @@ public abstract class FileUtil {
                     String[] split = s.split(File.separator);
                     String lastSubDir = split[split.length - 1];
                     final String path = cwdUri.getPath();
-                    if (path != null && !path.contains(lastSubDir)) return getFullCWDUriSlow(param);
+                    if (path != null && !path.contains(lastSubDir)) {
+                        // Fix: eg DCIM folder as target where pushing a file to it then makes the
+                        // listing empty from using this as fallback here. Shouldn't fallback anyway
+                        // as the faster custom way does have it correct.
+                        String chroot = getUriStoragePathFullFromDocumentFile(result, "");
+                        if (chroot == null || !chroot.contains(s)) {
+                            return getFullCWDUriSlow(param);
+                        }
+                    }
                     return result.getUri();
                 }
             } catch (NullPointerException e) {

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -4,15 +4,21 @@ import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.UriPermission;
+import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.documentfile.provider.DocumentFile;
 import android.util.Log;
+import android.util.Pair;
 
+
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,14 +28,22 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
+import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.Util;
 
 
 public abstract class FileUtil {
 
     private static final String LOG = "FileUtil";
+
+    public enum TYPE {
+        file,
+        dir
+    }
 
     /**
      * Copy a file. The target file may even be on external SD card for Kitkat.
@@ -121,7 +135,8 @@ public abstract class FileUtil {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 // Storage Access Framework
                 DocumentFile targetDocument = getDocumentFile(target, false, context);
-                outStream =  new ParcelFileDescriptor.AutoCloseOutputStream(context.getContentResolver().openFileDescriptor(targetDocument.getUri(), "rw"));
+                outStream = new ParcelFileDescriptor.AutoCloseOutputStream(context.getContentResolver()
+                        .openFileDescriptor(targetDocument.getUri(), "rw"));
             } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT) {
                 // Workaround for Kitkat ext SD card
                 return MediaStoreHack.getOutputStream(context, target.getPath());
@@ -244,7 +259,8 @@ public abstract class FileUtil {
                 return false;
             }
             try {
-                if(DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(), target.getName()) != null) {
+                if((DocumentsContract.renameDocument(context.getContentResolver(), document.getUri(),
+                        target.getName()) != null)) {
                     return true;
                 }
             } catch (FileNotFoundException e) {
@@ -371,6 +387,25 @@ public abstract class FileUtil {
             }
         }
         return false;
+    }
+
+    // Performance improvement with DocumentFile. As we can avoid a finding of the file this way since
+    // create will far more quickly create it and give it along with that. Thus, needed a way to return
+    // DocumentFile at creation time.
+    public static DocumentFile mkfile(final File file, Context context, String mime) throws IOException {
+        try {
+            final String filename = file.getName();
+            // Travel only to the dir for where the file goes:
+            Uri uri = getFullCWDUri("", file.getPath().substring(0, file.getPath().lastIndexOf(File.separator)));
+            // Can't create a file in dirs that have eg the symbol "?".
+            //  Can create a folder with it.
+            //  Can even create a file in a dirs that have # symbol.
+            DocumentFile dfile = FileUtil.getDocumentFileFromUri(uri).createFile(mime, filename);
+            if (dfile != null) return dfile;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     /**
@@ -573,12 +608,88 @@ public abstract class FileUtil {
      * null is returned.
      */
     @TargetApi(Build.VERSION_CODES.KITKAT)
-    private static String getExtSdCardFolder(final File file, Context context) {
+    private static String getExtSdCardFolder(final FileUtil.Gen file, Context context) {
+        boolean isDocFile = file.getOb() instanceof DocumentFile; // double check
+        if (Util.useScopedStorage() && isDocFile) {
+            return getExtSdCardFolderScopedStorage(file);
+        } else {
+            return getExtSdCardFolderOld(file, context);
+        }
+    }
+
+    public static String getExtSdCardFolderScopedStorage(final FileUtil.Gen file) {
+        try {
+            String s = file.getCanonicalPath();
+            String base = getSdCardBaseFolderScopedStorage();
+            String name = getSdCardNameScopedStorage();
+            if (name != null && !name.isEmpty() && s.contains(name)) {
+                String base2 = getTreeUriStoragePath((DocumentFile) file.getOb());
+                if (base2 != null) {
+                    if (base2.contains(File.separator)) {
+                        base2 = base2.substring(0, base2.lastIndexOf(File.separator));
+                    }
+                    base2 = base2.substring(0, base2.indexOf(name) + name.length());
+                    // need to return eg "/storage/sd card"
+                    return base + File.separator + base2;
+                }
+            }
+        } catch (IOException e) {
+            //
+        }
+        return null;
+    }
+
+    /*
+     * Used to get eg "/storage" since URIs for whatever reasons omit this.
+     * */
+    public static String getSdCardBaseFolderScopedStorage() {
+        final File[] f = ContextCompat.getExternalFilesDirs(App.getAppContext(), null);
+        String path = null;
+        for (File each : f) {
+            final String eachPath = each.getPath();
+            final Uri uri = FileUtil.getTreeUri();
+            if (uri == null) return null;
+            String s = cleanupUriStoragePath(uri);
+            try {
+                // Only want the sd card folder
+                if (s != null) s = s.substring(0, s.indexOf(File.pathSeparator));
+            } catch (Exception e) {
+                return null;
+            }
+            if (s != null) {
+                if (eachPath.contains(s)) {
+                    // Found the sd card path eg "/storage/[sd card]/Temp" should return as "/storage"
+                    // as the DocumentFile Uri will contain the [sd card] all the way to the picked folder.
+                    path = eachPath.substring(0, eachPath.indexOf(s) - 1);
+                }
+            }
+        }
+        return path;
+    }
+
+    /*
+     * Obtains only the sd card folder name or null if sd card is not being used
+     * */
+    public static String getSdCardNameScopedStorage() {
+        final Uri uri = FileUtil.getTreeUri();
+        if (uri == null) return null;
+        String s = cleanupUriStoragePath(uri);
+        if (s.contains("primary:")) return null; // It is definitely not on the sd card.
+        try {
+            // Only want the sd card folder name
+            s = s.substring(0, s.indexOf(File.pathSeparator));
+            return s;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static String getExtSdCardFolderOld(final FileUtil.Gen file, Context context) {
         String[] extSdPaths = getExtSdCardPaths(context);
         try {
             for (int i = 0; i < extSdPaths.length; i++) {
                 if (file.getCanonicalPath().startsWith(extSdPaths[i])) {
-                    return extSdPaths[i];
+                    return extSdPaths[i]; // returns eg "/storage/42F3-5677"
                 }
             }
         } catch (IOException e) {
@@ -595,7 +706,7 @@ public abstract class FileUtil {
      */
     @TargetApi(Build.VERSION_CODES.KITKAT)
     public static boolean isOnExtSdCard(final File file, Context c) {
-        return getExtSdCardFolder(file, c) != null;
+        return getExtSdCardFolder(new Gen<>(file), c) != null;
     }
 
     /**
@@ -608,24 +719,18 @@ public abstract class FileUtil {
      */
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     public static DocumentFile getDocumentFile(final File file, final boolean isDirectory, Context context) {
-        String baseFolder = getExtSdCardFolder(file, context);
+        String baseFolder = getExtSdCardFolder(new Gen<>(file), context);
         boolean originalDirectory = false;
+        String relativePath;
         if (baseFolder == null) {
             return null;
         }
 
-        String relativePath = null;
-        try {
-            String fullPath = file.getCanonicalPath();
-            if (!baseFolder.equals(fullPath))
-                relativePath = fullPath.substring(baseFolder.length() + 1);
-            else originalDirectory = true;
-        } catch (IOException e) {
-            return null;
-        } catch (Exception f) {
-            originalDirectory = true;
-            //continue
-        }
+        Pair<String, Boolean> pair = getRelativePath(context, file, baseFolder);
+        if (pair == null) return null;
+        relativePath = pair.first;
+        originalDirectory = pair.second;
+
         String as = FsSettings.getExternalStorageUri();
 
         Uri treeUri = null;
@@ -642,7 +747,7 @@ public abstract class FileUtil {
         }
 
         // start with root of SD card and then parse through document tree.
-        DocumentFile document = DocumentFile.fromTreeUri(context, treeUri);
+        DocumentFile document = FileUtil.getDocumentFileFromUri(treeUri);
         if (originalDirectory) return document;
         String[] parts = relativePath.split("\\/");
         for (int i = 0; i < parts.length; i++) {
@@ -650,7 +755,11 @@ public abstract class FileUtil {
 
             if (nextDocument == null) {
                 if ((i < parts.length - 1) || isDirectory) {
-                    nextDocument = document.createDirectory(parts[i]);
+                    if (!parts[i].isEmpty()) {
+                        nextDocument = document.createDirectory(parts[i]);
+                    } else {
+                        continue; // quick fix for an empty part causing major problems.
+                    }
                 } else {
                     nextDocument = document.createFile(DocumentsContract.Document.COLUMN_MIME_TYPE, parts[i]);
                 }
@@ -659,6 +768,100 @@ public abstract class FileUtil {
         }
 
         return document;
+    }
+
+    private static Pair<String, Boolean> getRelativePath(Context context, File file, String baseFolder) {
+        String relativePath = "";
+        boolean originalDirectory = false;
+        if (Util.useScopedStorage()) {
+            // Currently, relativePath needs to be "/file" for file or "" if no file is in
+            // fullPath for the following code to work right.
+            try {
+                Uri uri = getTreeUri();
+                if (uri != null) {
+                    DocumentFile dir = DocumentFile.fromSingleUri(context, uri);
+                    if (dir != null) {
+                        final String fullPath = file.getCanonicalPath();
+                        String clientPath = getScopedClientPath(file.getPath(), null, null);
+                        final String DocumentFilePath = getUriStoragePathFullFromDocumentFile(dir, clientPath);
+                        if (DocumentFilePath != null) {
+                            relativePath = fullPath.replace(DocumentFilePath, "");
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                return null;
+            } catch (Exception f) {
+                originalDirectory = true;
+                //continue
+            }
+        } else {
+            // This following code isn't working right on Android 8.0 sd card use. Bypassed with
+            // override of Android 11+ new storage use which has tested successfully as backward
+            // compatible with 8.0 sd card.
+            try {
+                String fullPath = file.getCanonicalPath();
+                if (!baseFolder.equals(fullPath))
+                    relativePath = fullPath.substring(baseFolder.length() + 1);
+                else originalDirectory = true;
+            } catch (IOException e) {
+                return null;
+            } catch (Exception f) {
+                originalDirectory = true;
+                //continue
+            }
+        }
+        return new Pair<>(relativePath, originalDirectory);
+    }
+
+    /*
+     * The param is tangled with the paths at times so that is necessary to include at specific times.
+     * The meaning can change depending on slash or no slash since the param contains files or just dirs.
+     * */
+    public static DocumentFile getDocumentFileWithParamScopedStorage(String param, @Nullable String cwd, String clientPath) {
+        DocumentFile f = null;
+        // affected by param having slash or not; empty or not
+        Uri uri = FileUtil.getFullCWDUri(cwd != null ? cwd : param, clientPath);
+        if (uri != null) {
+            try {
+                // Get the file
+                String mParam = param;
+                if (param.contains(File.separator)) {
+                    try {
+                        mParam = param.substring(param.lastIndexOf(File.separator) + 1);
+                    } catch (NullPointerException e) {
+                        mParam = null;
+                    }
+                }
+                // param affects above but down there its file only:
+                f = FileUtil.customFindFile(uri, (mParam != null ? mParam : param), FileUtil.TYPE.file, clientPath);
+                if (f == null)
+                    f = FileUtil.getDocumentFileFromUri(uri).findFile((mParam != null ? mParam : param));
+            } catch (NullPointerException e) {
+                //
+            }
+        }
+        return f;
+    }
+
+    /*
+     * Basic switch out of File to DocumentFile. Can't always be used as the File Uri isn't compatible
+     * with scoped storage. But, won't cause security failure for specific uses.
+     * */
+    public static DocumentFile getDocumentFileFromFileScopedStorage(File f, String clientPath) {
+        if (Util.useScopedStorage()) {
+            Uri uri = FileUtil.getFullCWDUri(f.getPath(), clientPath);
+            if (uri != null) return FileUtil.getDocumentFileFromUri(uri);
+        }
+        return null;
+    }
+
+    public static DocumentFile getDocumentFileFromUri(Uri uri) {
+        // For DocumentFile, to move into sub folders, the user path cannot start with /
+        // Say a user enters in "/test" inside the client, the string that is received will be "test".
+        // findFile("test") for getting the sub dir "test" contents works.
+        if (uri != null) return DocumentFile.fromTreeUri(App.getAppContext(), uri);
+        return null;
     }
 
     // Utility methods for Kitkat
@@ -693,5 +896,359 @@ public abstract class FileUtil {
             return 0;
         }
         return 0;
+    }
+
+    /*
+     * Retrieves the Uri required to use scoped storage.
+     * */
+    public static Uri getTreeUri() {
+        // Does not change unless user uses the picker again
+        List<UriPermission> list = App.getAppContext().getContentResolver().getPersistedUriPermissions();
+        if (list.size() > 0 && list.get(0) != null) {
+            // Get the picker path and then tack on any user provided path in the client.
+            return list.get(0).getUri();
+        }
+        return null;
+    }
+
+    /*
+     * Uses DocumentFile.findFile() to get the Uri for the target dir but does it the slow way as
+     * findFile() has a major performance issue.
+     */
+    public static Uri getFullCWDUriSlow(String param) {
+        Uri uri = getTreeUri();
+        if (uri != null) {
+            try {
+                String s = getScopedClientPath(param, null, null);
+                if (s.isEmpty() && param.contains(File.separator)) {
+                    s = param.substring(0, param.lastIndexOf(File.separator));
+                }
+                String[] split = s.split(File.separator);
+                for (String value : split) {
+                    if (value.isEmpty()) continue;
+                    String part = value.replaceAll(File.separator, "");
+                    DocumentFile dFile = FileUtil.getDocumentFileFromUri(uri).findFile(part);
+                    if (dFile != null) uri = dFile.getUri();
+                }
+                return uri;
+            } catch (NullPointerException e) {
+                //
+            }
+        }
+        return null;
+    }
+
+    /*
+     * Mainly uses DocumentsContract to move through the dir's and files for speed.
+     * On an issue - should the faster but complex code fail - falls back to the incredibly slower
+     * DocumentFile.findFile() to get it.
+     */
+    public static Uri getFullCWDUri(String param, String clientPath) {
+        Uri uri = getTreeUri();
+        if (uri != null) {
+            try {
+                final int paramDirCount = param.split(File.separator).length;
+                final boolean makeParamNull = param.isEmpty() || paramDirCount > 1;
+                final String mParam = makeParamNull ? null : param;
+                final boolean isDir = param.contains(File.separator) || param.isEmpty();
+                final TYPE type = isDir ? TYPE.dir : TYPE.file;
+                final DocumentFile result = customFindFile(uri, mParam, type, clientPath);
+                if (result != null) {
+                    Uri cwdUri = result.getUri();
+                    // Double check and do the slow way if needed
+                    String s = getScopedClientPath(clientPath, null, null);
+                    if (s.isEmpty() && param.contains(File.separator)) {
+                        s = param.substring(0, param.lastIndexOf(File.separator));
+                    }
+                    String[] split = s.split(File.separator);
+                    String lastSubDir = split[split.length - 1];
+                    final String path = cwdUri.getPath();
+                    if (path != null && !path.contains(lastSubDir)) return getFullCWDUriSlow(param);
+                    return result.getUri();
+                }
+            } catch (NullPointerException e) {
+                //
+            }
+        }
+        return null;
+    }
+
+    /*
+     * https://stackoverflow.com/questions/41096332/issues-traversing-through-directory-hierarchy-with-android-storage-access-framew
+     * Thanks to spring.ace for providing an example.
+     * HUGE performance improvement over DocumentFile.findFile().
+     * Use at least until Google fixes DocumentFile.findFile() performance (should it ever happen).
+     */
+    public static DocumentFile customFindFile(Uri dirUri, @Nullable String filename, TYPE type, String clientPath) {
+        ContentResolver contentResolver = App.getAppContext().getContentResolver();
+        Uri uri = DocumentsContract.buildChildDocumentsUriUsingTree(dirUri,DocumentsContract
+                .getTreeDocumentId(dirUri));
+        DocumentFile f = null;
+        List<Uri> uriList = new LinkedList<>();
+        uriList.add(uri);
+        final String chroot = FsSettings.getDefaultChrootDir().getPath();
+        String userPath = getScopedClientPath(clientPath, null, null);
+        if (userPath.contains(chroot)) userPath = userPath.replace(chroot, "");
+        if (userPath.contains(File.separator)) {
+            // Stop initial empty from being in the array as that messes things up
+            if (userPath.startsWith(File.separator))
+                userPath = userPath.replaceFirst(File.separator, "");
+        }
+        String[] userPathEachDir = userPath.split(File.separator);
+        if (userPathEachDir.length == 1 && userPathEachDir[0].isEmpty()) {
+            userPathEachDir = new String[0];
+        }
+        final int userPathMax = userPathEachDir.length;
+        int userPathLoc = 0;
+        boolean dirMovementFinished = userPathMax == 0 && type == TYPE.file;
+        boolean end = false;
+        while (!end) {
+            uri = uriList.remove(0);
+            try (Cursor c = contentResolver.query(uri, new String[]{
+                            DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                            DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                            DocumentsContract.Document.COLUMN_MIME_TYPE},
+                    null, null, null)) {
+                while (c!= null && c.moveToNext()) {
+                    final String docId = c.getString(0);
+                    final String name = c.getString(1);
+                    final String mime = c.getString(2);
+                    if (isDirectory(mime) && userPathLoc < userPathMax) {
+                        // Move to the target folder from the chosen dir using user supplied path
+                        if (isMatchFound(name, userPathEachDir[userPathLoc])) {
+                            // Add so it can move into on next loop
+                            userPathLoc++;
+                            final Uri mUri = DocumentsContract.buildChildDocumentsUriUsingTree(dirUri, docId);
+                            uriList.add(mUri);
+                            if (userPathLoc == userPathMax) {
+                                // If type is dir, then once path is found - including any sub
+                                // path - it should stop here. Whereas file should continue.
+                                dirMovementFinished = true;
+                                if (type == TYPE.dir) {
+                                    // Now we can find the dir and return that
+                                    Uri mUri2 = DocumentsContract.buildDocumentUriUsingTree(uri, docId);
+                                    f = FileUtil.getDocumentFileFromUri(mUri2);
+                                    end = true;
+                                    break;
+                                }
+                            }
+                        }
+                    } else if (dirMovementFinished && isMatchFound(name, filename)) {
+                        // Now we can find the file and return the Uri for that
+                        Uri mUri = DocumentsContract.buildDocumentUriUsingTree(uri, docId);
+                        f = FileUtil.getDocumentFileFromUri(mUri);
+                        end = true;
+                        break;
+                    } else if (type == TYPE.dir && isMatchFound(name, filename != null ? filename : userPath)) {
+                        // Now we can find the file and return the Uri for that
+                        Uri mUri = DocumentsContract.buildDocumentUriUsingTree(uri, docId);
+                        f = FileUtil.getDocumentFileFromUri(mUri);
+                        end = true;
+                        break;
+                    }
+                }
+            }
+            if (uriList.isEmpty()) end = true;
+        }
+        if (type == TYPE.file && f != null && f.isDirectory()) return null;
+        // Fix for empty folder with no user provided client path:
+        if (type == TYPE.dir && f == null) {
+            f = FileUtil.getDocumentFileFromUri(dirUri);
+        }
+        return f;
+    }
+
+    /*
+     * Checks if DocumentsContract entry is a dir or not
+     */
+    private static boolean isDirectory(String mimeType) {
+        // As DocumentsContract.buildChildDocumentsUriUsingTree() states:
+        // "Must be a directory with MIME type of DocumentsContract.Document.MIME_TYPE_DIR."
+        return DocumentsContract.Document.MIME_TYPE_DIR.equals(mimeType);
+    }
+
+    /*
+     * Compares two Strings to see if they match
+     */
+    public static boolean isMatchFound(String s1, String s2) {
+        return s1.equals(s2);
+    }
+
+    /*
+     * Cleans up a Uri tree path that contains non-path stuff such as "tree:",  ":", etc.
+     */
+    public static String cleanupUriStoragePath(Uri uri) {
+        if (uri == null) return "";
+        String s = uri.getPath();
+        if (s != null && s.contains("tree:")) s = s.replace("tree:", "");
+        else if (s != null && s.contains("/tree/")) s = s.replace("/tree/", "");
+        if (s != null && s.contains(File.pathSeparator)) {
+            String s2 = s.substring(0, s.indexOf(File.pathSeparator) - 1);
+            s = s.substring(s.lastIndexOf(s2));
+        }
+        return s;
+    }
+
+    /*
+     * Gets the picker path directly from the DocumentFile which doesn't include eg "/storage/"
+     */
+    public static String getTreeUriStoragePath(DocumentFile file) {
+        if (file == null) return null;
+        String path = cleanupUriStoragePath(file.getUri()); // gets path from user root on out
+        if (path != null) {
+            // Make compatible with sub folders
+            // "primary:" seems to be internal verses just the ":" found with sd card.
+            // Well, sd card use could also be explained as "[sd card name]:" verses "[name for internal]:"
+            if (path.contains("primary:")) {
+                // Internal storage
+                path = path.replace("primary:", "");
+            } else if (path.contains(":")) {
+                // We can know sd card path from the Uri so nothing else is needed :)
+                path = path.replace(":", File.separator);
+            }
+            // Need eg /storage/emulated/0/ for internal or /storage/ for sd card
+            return path;
+        }
+        return null;
+    }
+
+    /*
+     * Gets the full path using the DocumentFile including eg "/storage/ and all the way to the picker folder
+     */
+    public static String getUriStoragePathFullFromDocumentFile(DocumentFile file, String param) {
+        String partial = getTreeUriStoragePath(file);
+        if (partial != null) {
+            String chrootPath = FsSettings.getDefaultChrootDir().getPath();
+            // Fix an issue with older Android versions using the new code getting the path wrong
+            // here because of using Manage users chroot field. Chroot will contain the whole path.
+            String preLastDir = partial;
+            String lastDir = partial;
+            if (partial.contains(File.separator)) {
+                preLastDir = partial.substring(0, partial.lastIndexOf(File.separator));
+                lastDir = partial.substring(partial.lastIndexOf(File.separator));
+            }
+            if (chrootPath.contains(preLastDir) && !chrootPath.endsWith(lastDir)) {
+                // Moving up or file
+                return chrootPath + lastDir;
+            } else if (chrootPath.endsWith(partial) && partial.split(File.separator).length > 1) {
+                // Don't duplicate
+                return chrootPath;
+            }
+            // Need eg /storage/emulated/0/TestMain/TestSub/ or /storage/3abc-sdcard/Test/
+            final boolean isSDCard = getSdCardNameScopedStorage() != null;
+            if (isSDCard) return chrootPath + File.separator + partial;
+            else {
+                // Includes various checks & fixes for variances as seen on one device and internal
+                if (!chrootPath.endsWith(File.separator)) chrootPath += File.separator;
+                if (!param.contains(File.separator)) {
+                    return chrootPath; // file (dirs only here.) or empty
+                }
+                final String clientPath = getScopedClientPath(param, null, null);
+                if (clientPath.startsWith(File.separator) && chrootPath.endsWith(File.separator)) {
+                    chrootPath = chrootPath.substring(0, chrootPath.length() - 1);
+                }
+                return chrootPath + clientPath;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the client path or empty if at chroot from any of the supplied values.
+     * At the very least:
+     * @param s must be supplied which is the full path of the current dir.
+     * */
+    public static String getScopedClientPath(String s, @Nullable File f, @Nullable String t) {
+        if (s == null || s.isEmpty()) return ""; // at root
+        String tree;
+        if (t != null) tree = t;
+        else tree = FileUtil.cleanupUriStoragePath(FileUtil.getTreeUri());
+        if (tree.contains(File.pathSeparator)) tree = tree.substring(tree.indexOf(File.pathSeparator) + 1);
+        String param;
+        if (f != null) param = f.toString();
+        else param = s;
+        if (param.contains(tree)) param = param.substring(param.indexOf(tree) + tree.length());
+        return param;
+    }
+
+    /**
+     * Used to deduplicate some File and DocumentFile methods as eg .isDirectory() applies to both
+     * Thus, it gets rid of some horrible duplication that would have happened otherwise.
+     */
+    public static class Gen<T> {
+        T ob;
+
+        public Gen(T o1) {
+            ob = o1;
+        }
+
+        public T getOb() {
+            return ob;
+        }
+
+        public boolean exists() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).exists();
+            else return ((File) getOb()).exists();
+        }
+
+        public String getName() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).getName();
+            else return ((File) getOb()).getName();
+        }
+
+        public boolean isDirectory() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).isDirectory();
+            else return ((File) getOb()).isDirectory();
+        }
+
+        public long length() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).length();
+            else return ((File) getOb()).length();
+        }
+
+        public long lastModified() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).lastModified();
+            else return ((File) getOb()).lastModified();
+        }
+
+        public boolean isFile() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).isFile();
+            else return ((File) getOb()).isFile();
+        }
+
+        public boolean canRead() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).canRead();
+            else return ((File) getOb()).canRead();
+        }
+
+        public boolean canWrite() {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).canWrite();
+            else return ((File) getOb()).canWrite();
+        }
+
+        public String getCanonicalPath() throws IOException {
+            if (getOb() instanceof DocumentFile) return ((DocumentFile) getOb()).getUri().getPath();
+            else return ((File) getOb()).getCanonicalPath();
+        }
+    }
+
+    public static Gen convertDocumentFileToGen(DocumentFile f) {
+        return new Gen<>(f);
+    }
+
+    public static Gen convertFileToGen(File f) {
+        return new Gen<>(f);
+    }
+
+    /*
+     * Use under certain conditions only as File use isn't fully compatible with scoped storage and
+     * will throw security exceptions under incorrect use.
+     * */
+    public static Gen createGenFromFile(File f) {
+        if (Util.useScopedStorage()) {
+            return FileUtil.convertDocumentFileToGen(FileUtil.getDocumentFileFromFileScopedStorage(f, f.getPath()));
+        } else {
+            return FileUtil.convertFileToGen(f);
+        }
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -1035,6 +1035,9 @@ public abstract class FileUtil {
                                     end = true;
                                     break;
                                 }
+                            } else if (!c.isLast()) {
+                                // fix: Don't continue in the dir as it can wrongly match
+                                break;
                             }
                         }
                     } else if (dirMovementFinished && isMatchFound(name, filename)) {


### PR DESCRIPTION
…ions onto it if they have issues with the old code.

**All final tests:**

  [x] == passed
  [] == not tested; not looked into
  [*] == couldn't connect on this device for unknown reason and not debugging this; not tested

    Continual Backups 1GB-81GB:
	Android 12 internal [x]
	Android 12 sd card  [x]
	-
	Android 8 internal  [x]
	Android 8 sd card   [x]
	-
	Android 7 internal  [*]
	Android 7 sd card   [*]
	-
	Android 6 internal  [x]
	Android 6 sd card   []

    Full restore of multiple backups 1GB-81GB:
	Android 12 internal [x]
	Android 12 sd card  [x]
	-
	Android 8 internal  [x]
	Android 8 sd card   [x]
	-
	Android 7 internal  [*]
	Android 7 sd card   [*]
	-
	Android 6 internal  []
	Android 6 sd card   []

    Filezilla:
	Android 12 internal [x] 
	Android 12 sd card  [x] 
	-
	Android 8 internal  [x]
	Android 8 sd card   [x]
	-
	Android 7 internal  [*]
	Android 7 sd card   [*]
	-
	Android 6 internal  [x]
	Android 6 sd card   []

    Other:
	Test backup and FileZilla after app reinstall [x] <- write external storage is a problem here (see known issues).
	Test older File code execution is still working + clean install [x] <- tested on Android 6 device.

    Successful tests include:
	movement
	creations
	deletions
	transfer up
	transfer down
	change of target location without restart of app
	target in sub folders
	target at picker location
	multi-clients (running at the same time and at separate times)
	multi-clients supplied different sub folders
	user added chroot
	picker
	sd card
	internal
	various folders & sub folder tests (eg duplicate looking but original sub folder paths)
	chroot
	files going to the correct folders
	multi file transfer
	etc

**Known issues:**

	o Some classes such as CmdRNFR and couple or so of others are not implemented with this code so certain uses could fail to work properly.
	
	o Android 12 is not allowing files to be created in dirs with eg "?" in the name but allows this with "#" and also fine with creating dir with "?" in the name.
	
	o At least on Android 12 with the new code, should eg FileZilla have a set remote path in site settings that is different from the app, then the new code currently
	  doesn't deal with this where the input param is blatantly incorrect.

	o When reinstalling app after having used write external storage, the app suggests its fine via the storage path, but it is not. Write external storage must be
	  used again or the code will fail to work. Hardened new code here against hard crashes but that's it.

**Random notes:**

	o Older storage code mostly kept the same and so older Android was tested for correct code execution against the new code.
	    Two exceptions to this are:
	    	o LIST code improvement is notable change with it otherwise seen as working fine.
	    	o Added code for older Android versions to use the new storage where possible to get the app working where it would otherwise fail to work at all.
	
	o Android 7.1.1 sd card didn't need the new code as it could read and write to the sd card with the old code.
	
	o FileZilla has a setting to increase its timeout so eg LIST failure due to amount of files can be further fixed by increasing that (is up to client application).
	    But, the new LIST optimizations greatly decreases the time so at least its much better overall.

	o Noting the device battery optimization to be complete. Eg Samsung needs Unrestricted to be set or connection failures will happen as the app gets killed (it will
	    happen even in the middle of use making it seem like the app code has a problem when it doesn't).