### PR TITLE
Flag added to PendingIntent

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -465,7 +465,7 @@ public class FsService extends Service implements Runnable {
         Intent restartService = new Intent(getApplicationContext(), this.getClass());
         restartService.setPackage(getPackageName());
         PendingIntent restartServicePI = PendingIntent.getService(
-                getApplicationContext(), 1, restartService, PendingIntent.FLAG_ONE_SHOT);
+                getApplicationContext(), 1, restartService, PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
         AlarmManager alarmService = (AlarmManager) getApplicationContext()
                 .getSystemService(Context.ALARM_SERVICE);
         alarmService.set(AlarmManager.ELAPSED_REALTIME,


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.