### PR TITLE
Fix WinSCP being unable to rmdir subdirectory

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -971,7 +971,12 @@ public abstract class FileUtil {
                         s = param.substring(0, param.lastIndexOf(File.separator));
                     }
                     String[] split = s.split(File.separator);
-                    String lastSubDir = split[split.length - 1];
+                    String lastSubDir;
+                    try {
+                        lastSubDir = split[split.length - 1];
+                    } catch (ArrayIndexOutOfBoundsException e) {
+                        lastSubDir = File.separator;
+                    }
                     final String path = cwdUri.getPath();
                     if (path != null && !path.contains(lastSubDir)) {
                         // Fix: eg DCIM folder as target where pushing a file to it then makes the


### PR DESCRIPTION
Change for scoped storage to fix app crash found with WinSCP rmdir use on directory while at root. Works successfully after this.