### PR TITLE
Fix for the PendingIntent app issue

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -465,7 +465,7 @@ public class FsService extends Service implements Runnable {
         Intent restartService = new Intent(getApplicationContext(), this.getClass());
         restartService.setPackage(getPackageName());
         PendingIntent restartServicePI = PendingIntent.getService(
-                getApplicationContext(), 1, restartService, PendingIntent.FLAG_ONE_SHOT);
+                getApplicationContext(), 1, restartService, PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
         AlarmManager alarmService = (AlarmManager) getApplicationContext()
                 .getSystemService(Context.ALARM_SERVICE);
         alarmService.set(AlarmManager.ELAPSED_REALTIME,


### PR DESCRIPTION
Officially putting in the fix for the following issue. I think it was an app crash without this on Android 12+

"Missing PendingIntent mutability flag More...
Inspection info:Apps targeting Android 12 and higher must specify either FLAG_IMMUTABLE or FLAG_MUTABLE when constructing a PendingIntent."