### PR TITLE
Add multi user for scoped storage

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -444,6 +444,12 @@ public class FsService extends Service implements Runnable {
                 }
             }
             for (SessionThread removeThread : toBeRemoved) {
+                if (Util.useScopedStorage()) {
+                    // Clean up for scoped multi user
+                    if (SessionThread.getUriString(removeThread.getName()) != null) {
+                        SessionThread.removeUriString(removeThread.getName());
+                    }
+                }
                 sessionThreads.remove(removeThread);
             }
 

--- a/app/src/main/java/be/ppareit/swiftp/FsSettings.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsSettings.java
@@ -21,15 +21,15 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 package be.ppareit.swiftp;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.UriPermission;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-
-import net.vrallev.android.cat.Cat;
 
 import java.io.File;
 import java.lang.reflect.Type;
@@ -57,14 +57,15 @@ public class FsSettings {
             String username = sp.getString("username", context.getString(R.string.username_default));
             String password = sp.getString("password", context.getString(R.string.password_default));
             String chroot = sp.getString("chrootDir", "");
+            String uriString = sp.getString("uriString", "");
             if (username == null || password == null || chroot == null) {
                 username = context.getString(R.string.username_default);
                 password = context.getString(R.string.password_default);
                 chroot = "";
             }
-            return new ArrayList<>(Collections.singletonList(new FtpUser(username, password, chroot)));
+            return new ArrayList<>(Collections.singletonList(new FtpUser(username, password, chroot, uriString)));
         } else {
-            FtpUser defaultUser = new FtpUser(context.getString(R.string.username_default), context.getString(R.string.password_default), "\\");
+            FtpUser defaultUser = new FtpUser(context.getString(R.string.username_default), context.getString(R.string.password_default), "\\", "");
             return new ArrayList<>(Collections.singletonList(defaultUser));
         }
     }
@@ -88,7 +89,7 @@ public class FsSettings {
         sp.edit().putString("users", gson.toJson(userList)).apply();
     }
 
-    public static void removeUser(String username) {
+    public static void removeUser(String username, boolean actualDelete) {
         SharedPreferences sp = getSharedPreferences();
         Gson gson = new Gson();
         List<FtpUser> users = getUsers();
@@ -99,11 +100,32 @@ public class FsSettings {
             }
         }
         users.removeAll(found);
+        if (actualDelete /*Don't do this on modify.*/) {
+            for (FtpUser user : found) {
+                removeUserUriPerm(user);
+            }
+        }
         sp.edit().putString("users", gson.toJson(users)).apply();
     }
 
+    private static void removeUserUriPerm(FtpUser user) {
+        final String userUriString = user.getUriString();
+        if (userUriString == null || userUriString.isEmpty()) return;
+        List<UriPermission> list = App.getAppContext().getContentResolver().getPersistedUriPermissions();
+        for (UriPermission uriToRemove : list) {
+            if (uriToRemove == null) continue;
+            final String s = uriToRemove.getUri().getPath();
+            if (s == null) continue;
+            if (s.equals(userUriString)) {
+                App.getAppContext().getContentResolver().releasePersistableUriPermission(uriToRemove.getUri(),
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+                break;
+            }
+        }
+    }
+
     public static void modifyUser(String username, FtpUser newUser) {
-        removeUser(username);
+        removeUser(username, false);
         addUser(newUser);
     }
 
@@ -151,11 +173,6 @@ public class FsSettings {
             // but this will probably not be what the user wants
             return App.getAppContext().getFilesDir();
         }
-        if (!chrootDir.canRead() || !chrootDir.canWrite()) {
-            Cat.e("We cannot read/write in the default directory, changing to application directory");
-            return App.getAppContext().getFilesDir();
-        }
-
         if (subFix != null) return new File(chrootDir, subFix);
         return chrootDir;
     }

--- a/app/src/main/java/be/ppareit/swiftp/Util.java
+++ b/app/src/main/java/be/ppareit/swiftp/Util.java
@@ -36,7 +36,7 @@ import java.util.TimeZone;
 abstract public class Util {
     final static String TAG = Util.class.getSimpleName();
     private static SharedPreferences sp = null;
-    private static boolean overrideSDKVer = false;
+    private static int useScoped = -1;
 
     public static byte byteOfInt(int value, int which) {
         int shift = which * 8;
@@ -117,12 +117,14 @@ abstract public class Util {
      * Uses an override for when File fails to work during a test as the user sets up the app.
      * */
     public static boolean useScopedStorage() {
+        if (useScoped != -1) return useScoped == 1; // gets used a lot so speed it up a little
         if (sp == null) sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
-        overrideSDKVer = sp.getBoolean("OverrideScopedStorageMinimum", false);
-        return Build.VERSION.SDK_INT >= 30 || overrideSDKVer;
+        final boolean choice = sp.getBoolean("AllowNewScopedStorage", false);
+        useScoped = choice ? 1 : 0;
+        return choice;
     }
 
-    public static void reGetStorageOverride() {
-        sp = null;
+    public static void resetScoped() {
+        useScoped = -1; // reset on pref change
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
@@ -85,12 +85,6 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
         updateRunningState();
         runningPref.setOnPreferenceChangeListener((preference, newValue) -> {
             if ((Boolean) newValue) {
-                if (Util.useScopedStorage() && FsSettings.getExternalStorageUri() == null) {
-                    // Seems like we are on a system that requires scoped storage,
-                    // but scoped storage has not yet been configured, force it now
-                    Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
-                    startActivityForResult(intent, ACTION_OPEN_DOCUMENT_TREE);
-                }
                 FsService.start();
             } else {
                 FsService.stop();
@@ -174,6 +168,36 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
             writeExternalStoragePref.setSummary(getString(R.string.write_external_storage_old_android_version_summary));
         }
 
+        final CheckBoxPreference newScoped = findPref("newScopedStorage");
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+        if (sp.getBoolean("NewScopedStorageUpgradeCheck", true)) {
+            // Don't break use if "write external storage" was used before the app update as the original
+            // code it now fully uses isn't compat with the newer one and would see major issues.
+            // Runs one time only on update as pref won't be checked after clean install / wipe.
+            // Code is executed on app start which happens automatically after app update.
+            if (writeExternalStoragePref.isChecked()) { // needs to be true to not break use
+                sp.edit().putBoolean("AllowNewScopedStorage", true).apply();
+                sp.edit().putBoolean("NewScopedStorageUpgradeCheck", false).apply();
+                writeExtMultiUserUpgradePath();
+            }
+        }
+
+        if (Util.useScopedStorage()) {
+            // Do not allow mixing of old setting with the new one!
+            newScoped.setChecked(true);
+            writeExternalStoragePref.setChecked(false);
+            writeExternalStoragePref.setEnabled(false);
+        } else {
+            newScoped.setChecked(false);
+        }
+        newScoped.setTitle(newScoped.getTitle() + " -> " + getString(R.string.manage_users_label));
+        newScoped.setOnPreferenceChangeListener((preference, newValue) -> {
+            writeExternalStoragePref.setChecked(false);
+            writeExternalStoragePref.setEnabled(!((boolean) newValue));
+            sp.edit().putBoolean("AllowNewScopedStorage", (boolean) newValue).apply();
+            Util.resetScoped();
+            return true;
+        });
 
         ListPreference themePref = findPref("theme");
         themePref.setSummary(themePref.getEntry());
@@ -214,6 +238,27 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
             return true;
         });
 
+    }
+
+    /*
+    * Multi user:
+    * Upgrade path for previous "write external storage" use so that it doesn't break on update.
+    * Populates the new uriString use of each user.
+    * */
+    private void writeExtMultiUserUpgradePath() {
+        List<UriPermission> oldList = App.getAppContext().getContentResolver().getPersistedUriPermissions();
+        if (oldList.size() == 0) return;
+        Uri uri = oldList.get(0).getUri();
+        if (uri == null) return;
+        List<FtpUser> userList = FsSettings.getUsers();
+        for (int i = 0; i < userList.size(); i++) {
+            if (userList.get(i) == null) continue;
+            FtpUser entry = new FtpUser(userList.get(i).getUsername(),
+                    userList.get(i).getPassword(),
+                    userList.get(i).getChroot(),
+                    uri.getPath());
+            FsSettings.modifyUser(userList.get(i).getUsername(), entry);
+        }
     }
 
     @RequiresApi(api = Build.VERSION_CODES.M)
@@ -261,118 +306,24 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
     public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
         Cat.d("onActivityResult called");
         if (requestCode == ACTION_OPEN_DOCUMENT_TREE && resultCode == Activity.RESULT_OK) {
-            if (resultData == null) return;
             Uri treeUri = resultData.getData();
-            if (treeUri == null) return;
             String path = treeUri.getPath();
             Cat.d("Action Open Document Tree on path " + path);
-            // *************************************
-            // The order following here is critical. They must stay ordered as they are.
-            setPermissionToUseExternalStorage(treeUri);
-            tryToUpgradeToScopedStorage(treeUri);
-            scopedStorageChrootOverride(treeUri);
-        }
-    }
 
-    private void setPermissionToUseExternalStorage(Uri treeUri) {
-        final CheckBoxPreference writeExternalStoragePref = findPref("writeExternalStorage");
-        if (isNotExternalStorage(treeUri)) {
-            writeExternalStoragePref.setChecked(false);
-        } else {
-            try {
+            final CheckBoxPreference writeExternalStoragePref = findPref("writeExternalStorage");
+            if (path.contains("primary:")) {
+                writeExternalStoragePref.setChecked(false);
+            } else {
+                FsSettings.setExternalStorageUri(treeUri.toString());
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    if (removeAllUriPermissions(treeUri)) {
-                        FsSettings.setExternalStorageUri(treeUri.toString());
-                        getActivity().getContentResolver()
-                                .takePersistableUriPermission(treeUri,
-                                        Intent.FLAG_GRANT_READ_URI_PERMISSION
-                                                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-                    }
+                    getActivity().getContentResolver()
+                            .takePersistableUriPermission(treeUri,
+                                    Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
                 }
                 writeExternalStoragePref.setChecked(true);
-            } catch (SecurityException e) {
-                // Harden code against crash: May reach here by adding exact same picker location but
-                // being removed at same time.
             }
         }
-    }
-
-    private boolean isNotExternalStorage(Uri treeUri) {
-        String folder = FileUtil.cleanupUriStoragePath(treeUri);
-        if (folder != null && folder.contains(":")) {
-            // Just get rid of the "primary:" part to get what we want (the user selected path/folder)
-            try {
-                folder = folder.substring(folder.indexOf(":") + 1);
-            } catch (IndexOutOfBoundsException e) {
-                folder = "";
-            }
-        }
-        return folder == null || folder.isEmpty();
-    }
-
-    /*
-     * If user is on older SDK, check if File can rw and if not then move to newer storage use.
-     * As we don't know what older SDK will have a problem where or not.
-     * Could just assume with this use but a check is fast.
-     * */
-    private void tryToUpgradeToScopedStorage(Uri treeUri) {
-        if (!Util.useScopedStorage()) {
-            DocumentFile df = FileUtil.getDocumentFileFromUri(treeUri);
-            if (df == null) return;
-            final String a11Path = FileUtil.getUriStoragePathFullFromDocumentFile(df, "");
-            if (a11Path == null) return;
-            File root = new File(a11Path);
-            if (!root.canRead() || !root.canWrite()) {
-                SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
-                // Fix: Use commit; override in next method using useScopedStorage() needs it.
-                sp.edit().putBoolean("OverrideScopedStorageMinimum", true).commit();
-            }
-        }
-    }
-
-    /*
-     * Override all and put path as chroot. Previously user chosen. On Android 11+ it is only
-     * decided now by the picker if its to be allowed on the Play Store unless allowance was made.
-     * */
-    private void scopedStorageChrootOverride(Uri treeUri) {
-        if (Util.useScopedStorage()) {
-            DocumentFile df = FileUtil.getDocumentFileFromUri(treeUri);
-            if (df == null) return;
-            final String scopedStoragePath = FileUtil.getUriStoragePathFullFromDocumentFile(df, "");
-            if (scopedStoragePath == null) return;
-            List<FtpUser> userList = FsSettings.getUsers();
-            for (int i = 0; i < userList.size(); i++) {
-                if (userList.get(i) == null) continue;
-                FtpUser entry = new FtpUser(userList.get(i).getUsername(), userList.get(i).getPassword(), scopedStoragePath);
-                FsSettings.modifyUser(userList.get(i).getUsername(), entry);
-            }
-        }
-    }
-
-    /*
-     * Clean up URI list since there's only one folder. They have a way of collecting on changes
-     * which causes an issue. More so only can use one.
-     * */
-    private boolean removeAllUriPermissions(Uri treeUri) {
-        List<UriPermission> oldList = App.getAppContext().getContentResolver().getPersistedUriPermissions();
-        if (oldList.size() == 0) return true;
-        // check against current and don't remove if only and same as it won't re-give same.
-        if (oldList.size() == 1) {
-            Uri uri = oldList.get(0).getUri();
-            if (uri != null) {
-                final String path = uri.getPath();
-                if (path != null) if (path.equals(treeUri.getPath())) return false;
-            }
-        }
-        // Release all
-        for (UriPermission uriToRemove : oldList) {
-            if (uriToRemove == null) continue;
-            getActivity().getContentResolver()
-                    .releasePersistableUriPermission(uriToRemove.getUri(),
-                            Intent.FLAG_GRANT_READ_URI_PERMISSION
-                                    | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
-        }
-        return true;
     }
 
     /**

--- a/app/src/main/java/be/ppareit/swiftp/gui/UserListFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/UserListFragment.java
@@ -80,7 +80,7 @@ public class UserListFragment extends Fragment {
                 .setMessage(getString(R.string.confirm_delete_message, item.getUsername()))
                 .setNegativeButton(android.R.string.no, null)
                 .setPositiveButton(android.R.string.yes, (dialogInterface, whichButton) -> {
-                    FsSettings.removeUser(item.getUsername());
+                    FsSettings.removeUser(item.getUsername(), true);
                     refreshUserList();
                 })
                 .create();

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
@@ -59,6 +59,9 @@ public class CmdPASS extends FtpCmd implements Runnable {
             sessionThread.writeString("230 Access granted\r\n");
             sessionThread.authAttempt(true);
             sessionThread.setChrootDir(user.getChroot());
+            if (Util.useScopedStorage()) {
+                SessionThread.putUriString(Thread.currentThread().getName(), user.getUriString());
+            }
         } else {
             Log.i(TAG, "Failed authentication, incorrect password");
             Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack

--- a/app/src/main/java/be/ppareit/swiftp/server/FtpUser.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/FtpUser.java
@@ -11,14 +11,15 @@ public class FtpUser {
     final private String mUsername;
     final private String mPassword;
     final private String mChroot;
+    final private String mUriString;
 
-    public FtpUser(@NonNull String username, @NonNull String password, @NonNull String chroot) {
+    public FtpUser(@NonNull String username, @NonNull String password, @NonNull String chroot, String uriString) {
         mUsername = username;
         mPassword = password;
 
         final File rootPath = new File(chroot);
         mChroot = rootPath.isDirectory() ? chroot : FsSettings.getDefaultChrootDir().getPath();
-
+        mUriString = uriString;
     }
 
     public String getUsername() {
@@ -31,5 +32,9 @@ public class FtpUser {
 
     public String getChroot() {
         return mChroot;
+    }
+
+    public String getUriString() {
+        return mUriString;
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
@@ -32,6 +32,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
@@ -52,6 +53,7 @@ public class SessionThread extends Thread {
     private boolean userAuthenticated = false;
     private File workingDir = FsSettings.getDefaultChrootDir();
     private File chrootDir = workingDir;
+    private static ConcurrentHashMap<String, String> uriString = null; // scoped match user to perm
     private Socket dataSocket = null;
     private File renameFrom = null;
     private LocalDataSocket localDataSocket;
@@ -422,6 +424,22 @@ public class SessionThread extends Thread {
             this.chrootDir = chrootDir;
             this.workingDir = chrootDir;
         }
+    }
+
+    public static String getUriString(String threadName) {
+        if (uriString == null) return "";
+        if (uriString.containsKey(threadName)) return uriString.get(threadName);
+        return "";
+    }
+
+    public static void putUriString(String threadName, String s) {
+        if (uriString == null) uriString = new ConcurrentHashMap<>();
+        uriString.put(threadName, s);
+    }
+
+    public static void removeUriString(String threadName) {
+        if (uriString == null) return;
+        uriString.remove(threadName);
     }
 
     public String makeSelectedTypesResponse(FileUtil.Gen gen) {

--- a/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FileUtil.java
@@ -34,6 +34,7 @@ import java.util.List;
 import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.Util;
+import be.ppareit.swiftp.server.SessionThread;
 
 
 public abstract class FileUtil {
@@ -909,14 +910,22 @@ public abstract class FileUtil {
     }
 
     /*
-     * Retrieves the Uri required to use scoped storage.
+     * Retrieves the URI assigned to a user upon connection that is required to use scoped storage
+     * and get the correct URI to work with.
      * */
     public static Uri getTreeUri() {
-        // Does not change unless user uses the picker again
+        String threadName = Thread.currentThread().getName();
+        String userUriString = SessionThread.getUriString(threadName);
+        if (userUriString == null || userUriString.isEmpty()) return null;
         List<UriPermission> list = App.getAppContext().getContentResolver().getPersistedUriPermissions();
         if (list.size() > 0 && list.get(0) != null) {
-            // Get the picker path and then tack on any user provided path in the client.
-            return list.get(0).getUri();
+            for (UriPermission perm : list) {
+                String uriString = perm.getUri().getPath();
+                if (uriString == null) continue;
+                if (uriString.equals(userUriString)) {
+                    return perm.getUri();
+                }
+            }
         }
         return null;
     }

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -28,4 +28,5 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
     <string name="acceptwifi_default" translatable="false">true</string>
     <string name="wakelock_default" translatable="false">true</string>
     <string name="writeExternalStorage_default" translatable="false">true</string>
+    <string name="writeNewExternalStorage_default" translatable="false">false</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -77,6 +77,13 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
                 android:defaultValue="@string/writeExternalStorage_default"
                 android:key="writeExternalStorage"
                 android:title="@string/writeExternalStorage_label" />
+
+            <CheckBoxPreference
+                android:defaultValue="@string/writeNewExternalStorage_default"
+                android:key="newScopedStorage"
+                android:drawableLeft="@drawable/ic_shared_dir"
+                android:drawableStart="@drawable/ic_shared_dir"
+                android:title="@string/writeExternalStorage_label" />
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
#### Important - Requires pull request:

- https://github.com/ppareit/swiftp/pull/205 for scoped storage to function without crashing with this pr applied.

Add "write external storage" from advanced into user edit/add chroot for multiple scoped storage locations on a single device. Other words: multiple users multiple storage locations and multiple connections simultaneously for "write external storage".

Notable changes:

- [ ]     1. The new scoped storage can now be disabled/enabled by user choice in advanced settings with an additional setting for *all* devices and Android versions.

- [ ]     2. Added back old "write external storage" (problems and all) that works as it did before the newer scoped code to bring it in alignment with the settings and scoped storage separation.

- [ ]     3. Added upgrade path from the old and new non-multi user "write external storage" to the newer multi user scoped code to avoid breaking things on app update. Since multi user code needs uriString added to each user to function correctly and previous scoped storage didn't have this.

- [ ]     4. New setting enabled by default only if "write external storage" was in use before update to avoid breaking while the app is running and as its not guaranteed a user will be aware of things. User can then change when becoming aware of the change or keep the new setting in use for the fixes and improvements.

- [ ]     5. Is no longer enabled by default on a clean app install even on Android versions that would require it in their expected way or where rw fails with the older code as I had it previously to make it easier for users. This is now fully up to the user to deal with. Brings it back to how the app was previously for good or bad.

- [ ]     6. Using Thread.currentThread().getName() and per user uriString to a thread safe ConcurrentHashMap holder to deal with getting the user tied String to static methods everywhere as it offers very low code changes. It has so far worked great. I'm therefore going with it instead of the more expected way which would result in lots of code changes.

- [ ]     7. Uses a tap on chroot in each user add/edit where it brings up the Android scoped storage picker.

- [ ]     8. Used existing R.strings to avoid adding further. The title, interaction, and default combined give a good idea of what is happening and what the user needs to do. Some users may be slightly confused but should get it after some minutes.

- [ ]     9. Fully checked against all tests found below.

All tests successful with this code:

Android 8 (File) [ALL TESTS PASS]
  user [x]
    add [x]
    delete [x]
    edit [x]
    chroot changes [x]
  WinSCP command line commands [x]
    internal [x]
      put [x]
      get [x]
      rmdir [x]
      rmdir with files in it [x]
      mkdir [x]
      cd [x]
      cd to multiple subdirs at once [x]
      cd .. [x]
      cd / [x]
      stat [x]
      delete [x]
      pwd [x]
      ls [x]
      quit [x]
      try to cd out of chroot without success [x]
      rename file [x]
      rename dir [x]
  internal multiple locations [x]
    file only [x]
    folder only [x]
    small folder [x]
    medium folder [x]
    large folder [x]
    7k files in a single folder [x]
  sd card [broken as expected and double checked against old build with same results]
  clean app install [x]
  tested via multiple clients [x]

Android 8 [ALL TESTS PASS]
  user [x]
    add [x]
    delete [x]
    edit [x]
    chroot changes [x]
  WinSCP command line commands [x]
    internal [x]
      put [x]
      get [x]
      rmdir [x]
      rmdir with files in it [x]
      mkdir [x]
      cd [x]
      cd to multiple subdirs at once [x]
      cd .. [x]
      cd / [x]
      stat [x]
      delete [x]
      pwd [x]
      ls [x]
      quit [x]
      try to cd out of chroot without success [x]
      rename file [x]
      rename dir [x]
      append [x]
    sd card [x]
      put [x]
      get [x]
      rmdir [x]
      rmdir with files in it [x]
      mkdir [x]
      cd [x]
      cd to multiple subdirs at once [x]
      cd .. [x]
      cd / [x]
      stat [x]
      delete [x]
      pwd [x]
      ls [x]
      quit [x]
      try to cd out of chroot without success [x]
      rename file [x]
      rename dir [x]
      append [x]
  internal multiple locations [x]
    file only [x]
    folder only [x]
    small folder [x]
    medium folder [x]
    large folder [x]
    7k files in a single folder [x]
  sd card multiple locations [x]
    file only [x]
    folder only [x]
    small folder [x]
    medium folder [x]
    large folder [x]
    7k files in a single folder [x]
  full file verification [x]
  all tests with each user for multiple location testing [x]
  continual backups to 2 users at internal and sd card [x]
  clean app install [x]
  tested via multiple clients [x]
  tested upgrade from current version [x]


Android 14 [ALL TESTS PASS]
  user [x]
    add [x]
    delete [x]
    edit [x]
    chroot changes [x]
  WinSCP command line commands [x]
    internal [x]
      put [x]
      get [x]
      rmdir [x]
      rmdir with files in it [x]
      mkdir [x]
      cd [x]
      cd to multiple subdirs at once [x]
      cd .. [x]
      cd / [x]
      stat [x]
      delete [x]
      pwd [x]
      ls [x]
      quit [x]
      try to cd out of chroot without success [x]
      rename file [x]
      rename dir [x]
      append [x]
    sd card [x]
      put [x]
      get [x]
      rmdir [x]
      rmdir with files in it [x]
      mkdir [x]
      cd [x]
      cd to multiple subdirs at once [x]
      cd .. [x]
      cd / [x]
      stat [x]
      delete [x]
      pwd [x]
      ls [x]
      quit [x]
      try to cd out of chroot without success [x]
      rename file [x]
      rename dir [x]
      append [x]
  internal multiple locations [x]
    file only [x]
    folder only [x]
    small folder [x]
    medium folder [x]
    large folder [x]
    7k files in a single folder [x]
  sd card multiple locations [x]
    file only [x]
    folder only [x]
    small folder [x]
    medium folder [x]
    large folder [x]
    7k files in a single folder [x]
  full file verification [x]
  all tests with each user for multiple location testing [x]
  continual backups to 3 users at internal and sd card simultaneously [x]
  backup restore validation [x]
  clean app install [x]
  tested via multiple clients [x]
  tested upgrade from current version [x]
  transfer (to) multi times same location with manual delete and keep WinSCP dirty (store code conflict not caught by anything above) [x]
  tested with signed release build [x]


Other tests not listed for various reasons were also successful.