### PR TITLE
Don't dump certain things into logcat on release builds eg password

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,16 @@
+# Make sure certain things are not dumped into logcat for signed builds eg password
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}
+-assumenosideeffects class net.vrallev.android.cat.Cat {
+    public static *** d(...);
+    public static *** v(...);
+    public static *** i(...);
+    public static *** w(...);
+    public static *** e(...);
+}


### PR DESCRIPTION
As stated here: https://github.com/ppareit/swiftp/pull/177#issuecomment-1350651254

However, I don't like this idea as it still dumps it in debug builds. Password should not be dumped in either case to something "public" in nature as logcat can be sent out with any Android issue including 3rd party apps. That is a security thing as well to guard against.

I would suggest instead a check on the line in SessionThread for "PASS" and/or "USER" and not log that. Since, outright commenting of that log entry has been expressed as not desired.

However, a proguard drop was desired so here's the pull request for that.

_Alternative or in addition: Write logs to app's own private space including/instead. Eg atm, I have a test for another reason that is showing log items in a scrolling TextView in the app. Its a nice easy way to see the behind the scenes logs for all users to diagnose issues._

_Can adjust if needed._