### PR TITLE
Fix signed build app crash on missing type

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,4 @@
+# Fix missing type error
+-keep class com.google.gson.reflect.TypeToken
+-keep class * extends com.google.gson.reflect.TypeToken
+-keep public class * implements java.lang.reflect.Type


### PR DESCRIPTION
Closes:

- https://github.com/ppareit/swiftp/issues/216

Signed builds crash at eg user save from missing type due to proguard minify.

_Can adjust if needed._