### PR TITLE
lockscreen tile security improvement

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/gui/FsTileService.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/FsTileService.java
@@ -22,6 +22,11 @@ public class FsTileService extends TileService {
 
     @Override
     public void onClick() {
+        if (isSecure()) unlockAndRun(this::clicked);
+        else clicked();
+    }
+
+    private void clicked() {
         if (getQsTile().getState() == Tile.STATE_INACTIVE)
             FsService.start();
         else if (getQsTile().getState() == Tile.STATE_ACTIVE)


### PR DESCRIPTION
Closes

- https://github.com/ppareit/swiftp/issues/214

Security improvement for lock screen app tile

Some quick notes:

- Tile on lock screen only starts app/server _after_ device is unlocked for improved security
- Uses isSecure() to check if device is locked
- Then uses unlockAndRun() to prompt user to unlock _then_ proceeds to start
- Tested code as containing no problems for Android 6, Android 7.1.1, and Android 14

https://developer.android.com/reference/android/service/quicksettings/TileService#isSecure()

https://developer.android.com/reference/android/service/quicksettings/TileService#unlockAndRun(java.lang.Runnable)