### PR TITLE
Add logging

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,11 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
             android:theme="@style/AppThemeDark" />
 
         <activity
+            android:name=".gui.LogActivity"
+            android:parentActivityName=".gui.MainActivity"
+            android:theme="@style/AppThemeDark" />
+
+        <activity
             android:name=".gui.ManageUsersActivity"
             android:parentActivityName=".gui.MainActivity"
             android:theme="@style/AppThemeDark" />

--- a/app/src/main/java/be/ppareit/swiftp/gui/LogActivity.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/LogActivity.java
@@ -1,0 +1,153 @@
+package be.ppareit.swiftp.gui;
+
+
+import android.animation.Animator;
+import android.animation.ArgbEvaluator;
+import android.animation.ObjectAnimator;
+import android.animation.ValueAnimator;
+import android.graphics.Color;
+import android.os.Bundle;
+
+import androidx.core.app.NavUtils;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.text.PrecomputedTextCompat;
+import androidx.core.widget.TextViewCompat;
+
+import android.view.MenuItem;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.R;
+import be.ppareit.swiftp.utils.Logging;
+
+public class LogActivity extends AppCompatActivity {
+
+    private ObjectAnimator anim = null;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        setTheme(FsSettings.getTheme());
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.logs_layout);
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        final TextView tv = findViewById(R.id.logs_textview);
+        tv.setText("...");
+        final ObjectAnimator loading = ObjectAnimator.ofObject(tv, "textColor",
+                new ArgbEvaluator(), Color.BLACK, Color.LTGRAY).setDuration(100);
+        loading.setRepeatCount(ValueAnimator.INFINITE);
+        loading.start();
+
+        //showLogcat(tv, loading);
+        Logging logging = new Logging();
+        showLog(tv, logging, loading);
+
+        clear(tv, logging);
+        refresh(tv, logging);
+    }
+
+    private String getLogcat() {
+        StringBuilder log = new StringBuilder();
+        try {
+            Process process = Runtime.getRuntime().exec("logcat -d");
+            BufferedReader bufferedReader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()));
+
+            String line;
+            while ((line = bufferedReader.readLine()) != null) {
+                log.append(line).append("\n\n");
+            }
+        } catch (IOException e) { /**/ }
+        return log.toString();
+    }
+
+    /*
+     * Use this over setText() for a major speed improvement on long text
+     * */
+    private PrecomputedTextCompat getPrecomputedText(TextView v, String s) {
+        PrecomputedTextCompat.Params params = TextViewCompat.getTextMetricsParams(v);
+        return PrecomputedTextCompat.create(s, params);
+    }
+
+    private void showLogcat(TextView v, ObjectAnimator loading) {
+        new Thread(() -> {
+            PrecomputedTextCompat ptc = getPrecomputedText(v, getLogcat());
+            LogActivity.this.runOnUiThread(() -> {
+                TextViewCompat.setPrecomputedText(v, ptc);
+                loading.end();
+            });
+        }).start();
+    }
+
+    private void showLog(TextView v, Logging logging, ObjectAnimator loading) {
+        new Thread(() -> {
+            PrecomputedTextCompat ptc = getPrecomputedText(v, logging.readLogFile());
+            LogActivity.this.runOnUiThread(() -> {
+                TextViewCompat.setPrecomputedText(v, ptc);
+                if (loading != null) loading.end();
+            });
+        }).start();
+    }
+
+    private void refresh(TextView tv, Logging logging) {
+        ImageView refresh = findViewById(R.id.logs_refresh_button);
+        refresh.setOnClickListener(v -> {
+            if (anim != null && anim.isRunning()) {
+                anim.end();
+                return;
+            }
+            anim = ObjectAnimator.ofFloat(v, "rotation", 0.0f, 360.0f);
+            anim.setDuration(500);
+            anim.addListener(new Animator.AnimatorListener() {
+                @Override
+                public void onAnimationStart(Animator animation) {
+                }
+
+                @Override
+                public void onAnimationEnd(Animator animation) {
+                    showLog(tv, logging, null);
+                }
+
+                @Override
+                public void onAnimationCancel(Animator animation) {
+                }
+
+                @Override
+                public void onAnimationRepeat(Animator animation) {
+                }
+            });
+            anim.setStartDelay(500);
+            anim.start();
+        });
+    }
+
+    private void clear(TextView tv, Logging logging) {
+        ImageView clear = findViewById(R.id.logs_clear_button);
+        clear.setOnClickListener(v -> {
+            if (tv.getText().toString().isEmpty()) return;
+            logging.clearLog();
+            tv.setText("");
+        });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            NavUtils.navigateUpFromSameTask(this);
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
@@ -56,6 +56,7 @@ import be.ppareit.swiftp.FsService;
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.R;
 import be.ppareit.swiftp.server.FtpUser;
+import be.ppareit.swiftp.utils.Logging;
 
 /**
  * This is the main activity for swiftp, it enables the user to start the server service
@@ -198,6 +199,18 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
         Preference aboutPref = findPref("about");
         aboutPref.setOnPreferenceClickListener(preference -> {
             startActivity(new Intent(getActivity(), AboutActivity.class));
+            return true;
+        });
+
+        Preference logsPref = findPref("logs");
+        logsPref.setOnPreferenceClickListener(preference -> {
+            startActivity(new Intent(getActivity(), LogActivity.class));
+            return true;
+        });
+
+        Preference logCheckbox = findPref("enableLogging");
+        logCheckbox.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!(boolean) newValue) new Logging().clearLog();
             return true;
         });
 

--- a/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
 
 import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.Logging;
 
 public class SessionThread extends Thread {
 
@@ -62,11 +63,13 @@ public class SessionThread extends Thread {
     private String[] formatTypes = {"Size", "Modify", "Type", "Perm"}; // types option of MLST/MLSD
     private int authFails = 0;
     private String hashingAlgorithm = "SHA-1";
+    private final String connIP;
 
     public SessionThread(Socket socket, LocalDataSocket dataSocket) {
         cmdSocket = socket;
         localDataSocket = dataSocket;
         sendWelcomeBanner = true;
+        connIP = cmdSocket.getInetAddress().toString();
     }
 
     /**
@@ -237,6 +240,9 @@ public class SessionThread extends Thread {
         if (sendWelcomeBanner) {
             writeString("220 SwiFTP " + App.getVersion() + " ready\r\n");
         }
+        Logging logging = new Logging();
+        logging.appendLog("\n\n\nSession started");
+        logging.appendLog("Connected IP: " + connIP);
         // Main loop: read an incoming line and process it
         try {
             final Reader reader = new InputStreamReader(cmdSocket.getInputStream());
@@ -245,9 +251,11 @@ public class SessionThread extends Thread {
                 String line;
                 line = in.readLine(); // will accept \r\n or \n for terminator
                 if (line != null) {
+                    logging.appendLog(line);
                     Cat.d("Received line from client: " + line);
                     FtpCmd.dispatchCommand(this, line);
                 } else {
+                    logging.appendLog("quitting...");
                     Cat.i("readLine gave null, quitting");
                     break;
                 }

--- a/app/src/main/java/be/ppareit/swiftp/utils/Logging.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/Logging.java
@@ -1,0 +1,102 @@
+package be.ppareit.swiftp.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+import be.ppareit.swiftp.App;
+
+public class Logging {
+
+    private SimpleDateFormat sdf = null;
+    private boolean logging = false;
+
+    public Logging() {
+        initializeLogging();
+    }
+
+    public void initializeLogging() {
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+        logging = sp.getBoolean("enableLogging", false);
+    }
+
+    public boolean isLoggingEnabled() {
+        return logging;
+    }
+
+    private void saveLogging(String s) {
+        new Thread(() -> {
+            controlSize();
+            try (FileOutputStream fos = App.getAppContext().openFileOutput("connLog",
+                    Context.MODE_PRIVATE | Context.MODE_APPEND)) {
+                fos.write(s.getBytes());
+            } catch (FileNotFoundException e) {
+                //
+            } catch (IOException e) {
+                //
+            }
+        }).start();
+    }
+
+    public void appendLog(String s) {
+        if (isLoggingEnabled()) {
+            if (sdf == null) sdf = new SimpleDateFormat("dd:hh:mm:ss.SSS", Locale.getDefault());
+            saveLogging(sdf.format(new Date()) + ": " + s + '\n');
+        }
+    }
+
+    public String readLogFile() {
+        if (!isLoggingEnabled()) return "";
+        try {
+            FileInputStream fis = App.getAppContext().openFileInput("connLog");
+            InputStreamReader inputStreamReader = new InputStreamReader(fis, StandardCharsets.UTF_8);
+            StringBuilder stringBuilder = new StringBuilder();
+            try (BufferedReader reader = new BufferedReader(inputStreamReader)) {
+                String line = reader.readLine();
+                while (line != null) {
+                    stringBuilder.append(line).append('\n');
+                    line = reader.readLine();
+                }
+            } catch (IOException e) {
+                // Error occurred when opening raw file for reading.
+            }
+            return stringBuilder.toString();
+        } catch (Exception e) {
+            //
+        }
+        return "";
+    }
+
+    public void clearLog() {
+        if (!isLoggingEnabled()) return;
+        new Thread(() -> {
+            try (FileOutputStream fos = App.getAppContext().openFileOutput("connLog", Context.MODE_PRIVATE)) {
+                fos.write("".getBytes());
+            } catch (FileNotFoundException e) {
+                //
+            } catch (IOException e) {
+                //
+            }
+        }).start();
+    }
+
+    /* // todo keep some amount of the old log?
+    * Don't all the log to keep growing or get too large.
+    * */
+    private void controlSize() {
+        final File file = new File(App.getAppContext().getFilesDir(), "connLog");
+        if (file.length() >= 100000) clearLog();
+    }
+}

--- a/app/src/main/res/layout/logs_layout.xml
+++ b/app/src/main/res/layout/logs_layout.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/logs_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end"
+        android:gravity="end"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/logs_refresh_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="end"
+            android:scaleType="fitCenter"
+            android:src="@android:drawable/ic_menu_rotate"
+            app:tint="#00C5B4" />
+
+        <ImageView
+            android:id="@+id/logs_clear_button"
+            style="@style/Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:clickable="true"
+            android:focusable="true"
+            android:gravity="end"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_delete" />
+
+    </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/logs_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbarThumbVertical="@android:drawable/btn_default_small">
+
+        <TextView
+            android:id="@+id/logs_textview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="5dp"
+            android:background="#000000"
+            android:text=""
+            android:textIsSelectable="true"
+            android:textSize="15sp" />
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,4 +89,6 @@ Gemeldete Probleme und Verbesserungsvorschläge sind unter https://github.com/pp
     <string name="mixed_theme">Gemischtes Thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="enable_logging">Aktiviere das Logging</string>
+    <string name="manage_log_label">Protokoll…</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -143,5 +143,7 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="light_theme">Φωτεινό Θέμα</string>
     <string name="mixed_theme">Ανάμεικτο Θέμα</string>
 
+    <string name="enable_logging">Enable logging</string>
+    <string name="manage_log_label">Log…</string>
 </resources>
 

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -143,7 +143,7 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="light_theme">Φωτεινό Θέμα</string>
     <string name="mixed_theme">Ανάμεικτο Θέμα</string>
 
-    <string name="enable_logging">Enable logging</string>
-    <string name="manage_log_label">Log…</string>
+    <string name="enable_logging">Επιτρέπω την σύνδεση</string>
+    <string name="manage_log_label">Κούτσουρο…</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,5 +166,7 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
     </string>
     <string name="write_external_storage_old_android_version_summary">En estos dispositivos, toda lo guardado está disponible utilizando la jerarquía de archivos.</string>
 
+    <string name="enable_logging">Enable logging</string>
+    <string name="manage_log_label">Log…</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,7 +166,7 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
     </string>
     <string name="write_external_storage_old_android_version_summary">En estos dispositivos, toda lo guardado está disponible utilizando la jerarquía de archivos.</string>
 
-    <string name="enable_logging">Enable logging</string>
-    <string name="manage_log_label">Log…</string>
+    <string name="enable_logging">Habilitar el registro</string>
+    <string name="manage_log_label">Registro…</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Thème mixte</string>
     <string name="app_theme">Thème...</string>
 
+    <string name="enable_logging">Enable logging</string>
+    <string name="manage_log_label">Log…</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,6 +148,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Thème mixte</string>
     <string name="app_theme">Thème...</string>
 
-    <string name="enable_logging">Enable logging</string>
-    <string name="manage_log_label">Log…</string>
+    <string name="enable_logging">Activer la journalisation</string>
+    <string name="manage_log_label">Enregistrer…</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -93,4 +93,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Tema misto</string>
     <string name="app_theme">Tema...</string>
 
+    <string name="enable_logging">Abilita la registrazione</string>
+    <string name="manage_log_label">Tronco d\'albero…</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,4 +127,6 @@ https://github.com/ppareit/swiftp/issues を参照してください。\n\n
     <string name="mixed_theme">混合テーマ</string>
     <string name="app_theme">テーマ...</string>
 
+    <string name="enable_logging">ロギングを有効にします</string>
+    <string name="manage_log_label">ログ…</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -95,4 +95,6 @@ van de volgende versie staan op https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Gemengd thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="enable_logging">Logboekregistratie inschakelen</string>
+    <string name="manage_log_label">Logboek…</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -192,4 +192,6 @@ na stronie https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Na tych urządzeniach cały sklep jest dostępny przy użyciu hierarchii plików.</string>
 
+    <string name="enable_logging">Włącz logowanie</string>
+    <string name="manage_log_label">Dziennik…</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -108,4 +108,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Смешанная тема</string>
     <string name="app_theme">Тема...</string>
 
+    <string name="enable_logging">Включить ведение журнала</string>
+    <string name="manage_log_label">Бревно…</string>
 </resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -194,4 +194,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Në këto pajisje, e gjithë dyqani është në dispozicion duke përdorur hierarkinë e skedarit.</string>
 
+    <string name="enable_logging">Aktivizo regjistrimin</string>
+    <string name="manage_log_label">Regjistrohu…</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -127,4 +127,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">микед Тема</string>
     <string name="app_theme">Тема...</string>
 
+    <string name="enable_logging">Омогући пријаву</string>
+    <string name="manage_log_label">Пријава…</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -165,5 +165,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">На цих пристроях вся пам\'ять доступна за допомогою ієрархії файлів.</string>
 
-
+    <string name="enable_logging">Увімкнути журналювання</string>
+    <string name="manage_log_label">Журнал…</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -82,4 +82,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建议。\n\n
     <string name="storage_warning">警告：当前存储暂不可用，您可能需要取消挂载。</string>
     <string name="widget_name">FTP Server Widget</string>
 
+    <string name="enable_logging">启用日志记录</string>
+    <string name="manage_log_label">日志…</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -182,4 +182,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建議。\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">在這些裝置上，可以使用檔案階層標準來使用所有存儲空間。</string>
 
+    <string name="enable_logging">啟用日誌記錄</string>
+    <string name="manage_log_label">紀錄…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,7 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">On these devices, all store is available using the file hierarchy.</string>
 
+    <!-- since 3.1 -->
+    <string name="enable_logging">Enable logging</string>
+    <string name="manage_log_label">Log…</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -77,6 +77,14 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
                 android:defaultValue="@string/writeExternalStorage_default"
                 android:key="writeExternalStorage"
                 android:title="@string/writeExternalStorage_label" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="enableLogging"
+                android:drawableLeft="@drawable/ic_shared_dir"
+                android:drawableStart="@drawable/ic_shared_dir"
+                android:title="@string/enable_logging" />
+
         </PreferenceScreen>
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -90,6 +90,9 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         <Preference
             android:key="about"
             android:title="@string/about_label" />
+        <Preference
+            android:key="logs"
+            android:title="@string/manage_log_label" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
#### Closes

- https://github.com/ppareit/swiftp/issues/147

Added viewable connection log

#### Some quick notes:
- Show time stamps and the incoming client connection stuff as seen by SessionThread
- Manual refresh button
- Clear log button
- Enable/disable this feature in advanced settings
- Has a size limit of about 100,000 chars
- Tested on Android 6, Android 7.1.1, and Android 14
- Added log entry to show client IP during client connections
- Writes log to app private space for security
- Disable will also clear log
- Log text can be selected for copy (although people need to watch out for the password, etc in there if they do that)

#### Can use some improvements (but I'm not going to and someone else can) such as:
- Renaming the log so it stays around longer instead of outright clearing it (also needs UI to deal with showing multiple files or whatever)
- Keeping the sessions together instead of combining them? I originally had it like this but it changed as the code changed.
- Some log entries may at times get out of order due to the time it takes