### PR TITLE
Anonymous fix, connection limiter, and chroot selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,11 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
             android:parentActivityName=".gui.MainActivity"
             android:theme="@style/AppThemeDark" />
 
+        <activity
+            android:name=".gui.ManageAnonActivity"
+            android:parentActivityName=".gui.MainActivity"
+            android:theme="@style/AppThemeDark" />
+
         <service android:name="be.ppareit.swiftp.FsService" />
 
         <service android:name="be.ppareit.swiftp.NsdService" />

--- a/app/src/main/java/be/ppareit/swiftp/FsSettings.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsSettings.java
@@ -138,6 +138,14 @@ public class FsSettings {
         return port;
     }
 
+    public static int getAnonMaxConNumber() {
+        final SharedPreferences sp = getSharedPreferences();
+        String s = sp.getString("anon_max", "1");
+        int i = Integer.parseInt(s);
+        Log.v(TAG, "Using anon max connections: " + i);
+        return i;
+    }
+
     public static boolean shouldTakeFullWakeLock() {
         final SharedPreferences sp = getSharedPreferences();
         return sp.getBoolean("stayAwake", false);

--- a/app/src/main/java/be/ppareit/swiftp/gui/ManageAnonActivity.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/ManageAnonActivity.java
@@ -1,0 +1,136 @@
+package be.ppareit.swiftp.gui;
+
+
+import android.animation.ArgbEvaluator;
+import android.animation.ObjectAnimator;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.graphics.Color;
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.core.app.NavUtils;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.preference.PreferenceManager;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import net.vrallev.android.cat.Cat;
+
+import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.R;
+import be.ppareit.swiftp.utils.ChrootPicker;
+
+public class ManageAnonActivity extends AppCompatActivity {
+
+    private static final int ACTION_OPEN_DOCUMENT_TREE = 42;
+    ChrootPicker chrootPicker = null;
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        setTheme(FsSettings.getTheme());
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.anon_layout);
+
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(true);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+        }
+
+        chrootPicker = new ChrootPicker();
+        TextView chroot = findViewById(R.id.anon_chroot);
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+        String chrootString = sp.getString("anonChroot", "");
+        chroot.setText(chrootString);
+        chroot.setOnTouchListener((v, event) -> {
+            sp.edit().remove("anonChroot").apply();
+            sp.edit().remove("anonUriString").apply();
+            if (event.getAction() == MotionEvent.ACTION_DOWN) {
+                chrootPicker.showFolderPicker(chroot.getText().toString(), this, null);
+            }
+            return true;
+        });
+        chrootPicker.setOnTextEventListener(s -> {
+            chroot.setText(s);
+            sp.edit().putString("anonChroot", s).apply();
+        });
+        chrootPicker.setOnActionTreeEventListener(() -> {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            startActivityForResult(intent, ACTION_OPEN_DOCUMENT_TREE);
+        });
+
+        EditText anonMaxCon = findViewById(R.id.anon_max);
+        anonMaxCon.setText(String.valueOf(FsSettings.getAnonMaxConNumber()));
+        anonMaxCon.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                sp.edit().putString("anon_max", s.toString()).apply();
+            }
+        });
+
+        CheckBox anonCB = findViewById(R.id.anon_enable);
+        anonCB.setChecked(sp.getBoolean("allow_anonymous", false));
+        anonCB.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            SharedPreferences sp1 = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+            if (isChecked ) {
+                if (sp.getString("anonChroot", "").isEmpty()) {
+                    // Deny as workaround to problems like app crashing with scoped storage.
+                    anonCB.setChecked(false);
+                    final ObjectAnimator loading = ObjectAnimator.ofObject((TextView) chroot, "backgroundColor",
+                            new ArgbEvaluator(), Color.RED, Color.TRANSPARENT).setDuration(1000);
+                    loading.start();
+                    return;
+                }
+                sp1.edit().putBoolean("allow_anonymous", true).apply();
+            }
+            else sp1.edit().putBoolean("allow_anonymous", false).apply();
+        });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
+        super.onActivityResult(requestCode, resultCode, resultData);
+        Cat.d("onActivityResult called");
+        if (requestCode == ACTION_OPEN_DOCUMENT_TREE && resultCode == Activity.RESULT_OK) {
+            if (resultData == null) return;
+            Uri treeUri = resultData.getData();
+            if (treeUri == null) return;
+            String path = treeUri.getPath();
+            Cat.d("Action Open Document Tree on path " + path);
+            chrootPicker.save(this.getApplicationContext(), treeUri);
+            String uriString = treeUri.getPath();
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+            sp.edit().putString("anonUriString", uriString).apply();
+        }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            NavUtils.navigateUpFromSameTask(this);
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
@@ -110,6 +110,12 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
             return true;
         });
 
+        Preference manageAnonPref = findPref("manage_anon");
+        manageAnonPref.setOnPreferenceClickListener((preference) -> {
+            startActivity(new Intent(getActivity(), ManageAnonActivity.class));
+            return true;
+        });
+
         EditTextPreference portNumberPref = findPref("portNum");
         portNumberPref.setSummary(String.valueOf(FsSettings.getPortNumber()));
         portNumberPref.setOnPreferenceChangeListener((preference, newValue) -> {

--- a/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
@@ -1,12 +1,15 @@
 package be.ppareit.swiftp.gui;
 
 
-import android.app.AlertDialog;
+import android.app.Activity;
 import android.app.Fragment;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,17 +17,22 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import java.io.File;
+import net.vrallev.android.cat.Cat;
 
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.R;
 import be.ppareit.swiftp.server.FtpUser;
+import be.ppareit.swiftp.utils.ChrootPicker;
 
 public class UserEditFragment extends Fragment {
 
+    private static final int ACTION_OPEN_DOCUMENT_TREE = 42;
+
     private FtpUser item;
     private OnEditFinishedListener editFinishedListener;
-    private boolean isShowingFolderPicker = false;
+    private TextView chroot = null;
+    private String uriString = "";
+    private ChrootPicker chrootPicker = null;
 
     public static UserEditFragment newInstance(@Nullable FtpUser item, @NonNull OnEditFinishedListener listener) {
         UserEditFragment fragment = new UserEditFragment();
@@ -40,14 +48,21 @@ public class UserEditFragment extends Fragment {
         View root = inflater.inflate(R.layout.user_edit_layout, container, false);
         EditText username = (EditText) root.findViewById(R.id.user_edit_name);
         EditText password = (EditText) root.findViewById(R.id.user_edit_password);
-        TextView chroot = (TextView) root.findViewById(R.id.user_edit_chroot);
+        chrootPicker = new ChrootPicker();
+        chroot = (TextView) root.findViewById(R.id.user_edit_chroot);
         chroot.setText(FsSettings.getDefaultChrootDir().getPath());
         chroot.setOnFocusChangeListener((v, hasFocus) -> {
-            if (!hasFocus)
-                return;
-            showFolderPicker(chroot);
+            if (!hasFocus) return;
+            chrootPicker.showFolderPicker(chroot.getText().toString(), null, getContext());
         });
-        chroot.setOnClickListener(view -> showFolderPicker(chroot));
+        chroot.setOnClickListener(v -> {
+            chrootPicker.showFolderPicker(chroot.getText().toString(), null, getContext());
+        });
+        chrootPicker.setOnTextEventListener(s -> chroot.setText(s));
+        chrootPicker.setOnActionTreeEventListener(() -> {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+            startActivityForResult(intent, ACTION_OPEN_DOCUMENT_TREE);
+        });
 
         if (item != null) {
             username.setText(item.getUsername());
@@ -60,7 +75,7 @@ public class UserEditFragment extends Fragment {
             String newPassword = password.getText().toString();
             String newChroot = chroot.getText().toString();
             if (validateInput(newUsername, newPassword)) {
-                editFinishedListener.onEditActionFinished(item, new FtpUser(newUsername, newPassword, newChroot));
+                editFinishedListener.onEditActionFinished(item, new FtpUser(newUsername, newPassword, newChroot, uriString));
                 getActivity().onBackPressed();
             }
         });
@@ -68,30 +83,20 @@ public class UserEditFragment extends Fragment {
         return root;
     }
 
-    private void showFolderPicker(TextView chrootView) {
-        if (isShowingFolderPicker)
-            return;
-        isShowingFolderPicker = true;
-        final File startDir;
-        if (chrootView.getText().toString().isEmpty()) {
-            startDir = Environment.getExternalStorageDirectory();
-        } else {
-            startDir = new File((chrootView.getText().toString()));
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent resultData) {
+        Cat.d("onActivityResult called");
+        if (requestCode == ACTION_OPEN_DOCUMENT_TREE && resultCode == Activity.RESULT_OK) {
+            if (resultData == null) return;
+            Uri treeUri = resultData.getData();
+            if (treeUri == null) return;
+            String path = treeUri.getPath();
+            Cat.d("Action Open Document Tree on path " + path);
+            // *************************************
+            // The order following here is critical. They must stay ordered as they are.
+            chrootPicker.save(this.getContext(), treeUri);
+            uriString = treeUri.getPath();
         }
-        AlertDialog folderPicker = new FolderPickerDialogBuilder(getActivity(), startDir)
-                .setSelectedButton(R.string.select, path -> {
-                    final File root = new File(path);
-                    if (!root.canRead()) {
-                        showToast(R.string.notice_cant_read_write);
-                    } else if (!root.canWrite()) {
-                        showToast(R.string.notice_cant_write);
-                    }
-                    chrootView.setText(path);
-                })
-                .setNegativeButton(R.string.cancel, null)
-                .create();
-        folderPicker.setOnDismissListener(dialog -> isShowingFolderPicker = false);
-        folderPicker.show();
     }
 
     private boolean validateInput(String username, String password) {

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
@@ -19,9 +19,15 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
 package be.ppareit.swiftp.server;
 
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
+
+import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.Util;
+import be.ppareit.swiftp.utils.AnonymousLimit;
+import be.ppareit.swiftp.utils.Logging;
 
 public class CmdPASS extends FtpCmd implements Runnable {
     private static final String TAG = CmdPASS.class.getSimpleName();
@@ -44,8 +50,35 @@ public class CmdPASS extends FtpCmd implements Runnable {
             return;
         }
         if (attemptUsername.equals("anonymous") && FsSettings.allowAnonymous()) {
-            Log.i(TAG, "Guest logged in with email: " + attemptPassword);
-            sessionThread.writeString("230 Guest login ok, read only access.\r\n");
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+            final int anonMaxCon = Integer.parseInt(sp.getString("anon_max", "1"));
+            Logging logging = new Logging();
+            final int newCount = AnonymousLimit.incrementAndGet();
+            logging.appendLog("anon CURRENT client conn count: " + (newCount - 1));
+            logging.appendLog("anon MAX conn count: " + anonMaxCon);
+            if (newCount > anonMaxCon) {
+                Log.i(TAG, "Failed authentication, too many anonymous users connected.");
+                Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack
+                sessionThread.writeString("421 too many anonymous users connected.\r\n");
+                sessionThread.authAttempt(false);
+            } else {
+                Log.i(TAG, "Guest logged in with email: " + attemptPassword);
+                sessionThread.writeString("230 Guest login ok, read only access.\r\n");
+                final String anonChroot = sp.getString("anonChroot", "/storage/emulated/0" /*backwards compat*/);
+                final String anonUriString = sp.getString("anonUriString", "");
+                if (!anonChroot.isEmpty()) {
+                    sessionThread.setChrootDir(anonChroot);
+                    if (!anonUriString.isEmpty()) {
+                        SessionThread.putUriString(Thread.currentThread().getName(), anonUriString);
+                    } else if (Util.useScopedStorage()) {
+                        // Protect against app crashes/problems
+                        Log.i(TAG, "Failed authentication, too many anonymous users connected.");
+                        Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack
+                        sessionThread.writeString("421 too many anonymous users connected.\r\n");
+                        sessionThread.authAttempt(false);
+                    }
+                }
+            }
             return;
         }
         FtpUser user = FsSettings.getUser(attemptUsername);
@@ -59,6 +92,9 @@ public class CmdPASS extends FtpCmd implements Runnable {
             sessionThread.writeString("230 Access granted\r\n");
             sessionThread.authAttempt(true);
             sessionThread.setChrootDir(user.getChroot());
+            if (Util.useScopedStorage()) {
+                SessionThread.putUriString(Thread.currentThread().getName(), user.getUriString());
+            }
         } else {
             Log.i(TAG, "Failed authentication, incorrect password");
             Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack

--- a/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
@@ -35,6 +35,7 @@ import java.nio.ByteBuffer;
 
 import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.AnonymousLimit;
 
 public class SessionThread extends Thread {
 
@@ -256,6 +257,7 @@ public class SessionThread extends Thread {
             Cat.i("Connection was dropped");
         }
         closeSocket();
+        AnonymousLimit.decrement();
     }
 
     public void closeSocket() {

--- a/app/src/main/java/be/ppareit/swiftp/utils/AnonymousLimit.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/AnonymousLimit.java
@@ -1,0 +1,15 @@
+package be.ppareit.swiftp.utils;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AnonymousLimit {
+    static AtomicInteger anonUsersConnected = new AtomicInteger(0);
+
+    public static int incrementAndGet() {
+        return anonUsersConnected.incrementAndGet();
+    }
+
+    public static void decrement() {
+        if (anonUsersConnected.get() >= 1) anonUsersConnected.decrementAndGet();
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/utils/ChrootPicker.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/ChrootPicker.java
@@ -1,0 +1,124 @@
+package be.ppareit.swiftp.utils;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
+import androidx.documentfile.provider.DocumentFile;
+
+import java.io.File;
+
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.R;
+import be.ppareit.swiftp.Util;
+import be.ppareit.swiftp.gui.FolderPickerDialogBuilder;
+
+public class ChrootPicker {
+
+    public ChrootPicker() {
+    }
+
+    public interface OnTextEventListener {
+        void OnEvent(String s);
+    }
+
+    public interface OnActionEventListener {
+        void OnEvent();
+    }
+
+    public OnTextEventListener onTextEventListener;
+    public OnActionEventListener onActionEventListener;
+
+    public void setOnTextEventListener(OnTextEventListener onTextEventListener) {
+        this.onTextEventListener = onTextEventListener;
+    }
+
+    public void setOnActionTreeEventListener(OnActionEventListener onActionEventListener) {
+        this.onActionEventListener = onActionEventListener;
+    }
+
+    private boolean isShowingFolderPicker = false;
+
+    public void save(Context context, Uri treeUri) {
+        // *************************************
+        // The order following here is critical. They must stay ordered as they are.
+        setPermissionToUseExternalStorage(treeUri, context);
+        scopedStorageChrootOverride(treeUri);
+    }
+
+    private void setPermissionToUseExternalStorage(Uri treeUri, Context context) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                FsSettings.setExternalStorageUri(treeUri.toString());
+                context.getContentResolver()
+                        .takePersistableUriPermission(treeUri,
+                                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                                        | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            }
+        } catch (SecurityException e) {
+            // Harden code against crash: May reach here by adding exact same picker location but
+            // being removed at same time.
+        }
+    }
+
+    private void scopedStorageChrootOverride(Uri treeUri) {
+        if (Util.useScopedStorage()) {
+            DocumentFile df = FileUtil.getDocumentFileFromUri(treeUri);
+            if (df == null) return;
+            String newPath = "/storage/emulated/0/";
+            String treePath = treeUri.getPath();
+            if (treePath == null) return;
+            if (treePath.contains("primary:"))
+                treePath = treePath.substring(treePath.indexOf(":") + 1);
+            else if (treePath.contains(":")) {
+                newPath = "/storage/";
+                treePath = treePath.replace("/tree/", "");
+                treePath = treePath.replace(":", "/");
+            }
+            newPath += treePath;
+            if (onTextEventListener != null) onTextEventListener.OnEvent(newPath);
+        }
+    }
+
+    public void showFolderPicker(String s, @Nullable Activity a, Context fragment /*Fragment use*/) {
+        if (Util.useScopedStorage()) {
+            if (onActionEventListener != null) onActionEventListener.OnEvent();
+            return;
+        }
+        if (isShowingFolderPicker)
+            return;
+        isShowingFolderPicker = true;
+        final File startDir;
+        if (s.isEmpty()) {
+            startDir = Environment.getExternalStorageDirectory();
+        } else {
+            startDir = new File(s);
+        }
+        AlertDialog folderPicker = new FolderPickerDialogBuilder(a != null ? a : fragment, startDir)
+                .setSelectedButton(R.string.select, path -> {
+                    final File root = new File(path);
+                    if (!root.canRead()) {
+                        showToast(R.string.notice_cant_read_write,
+                                a != null ? a : fragment);
+                    } else if (!root.canWrite()) {
+                        showToast(R.string.notice_cant_write,
+                                a != null ? a : fragment);
+                    }
+                    if (onTextEventListener != null) onTextEventListener.OnEvent(path);
+                })
+                .setNegativeButton(R.string.cancel, null)
+                .create();
+        folderPicker.setOnDismissListener(dialog -> isShowingFolderPicker = false);
+        folderPicker.show();
+    }
+
+    private void showToast(int errorResId, Context context) {
+        Toast.makeText(context, errorResId, Toast.LENGTH_LONG).show();
+    }
+}

--- a/app/src/main/res/layout/anon_layout.xml
+++ b/app/src/main/res/layout/anon_layout.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="16dp"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/allow_anonymous_label"
+                android:textColor="#ffffff"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:text="@string/anonymous_summary" />
+
+        </LinearLayout>
+
+        <CheckBox
+            android:id="@+id/anon_enable"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:defaultValue="@string/allow_anonymous_default"
+            android:key="allow_anonymous"
+            android:paddingTop="10dp" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/anon_chroot"
+        style="@style/Widget.AppCompat.EditText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_shared_dir"
+        android:drawableLeft="@drawable/ic_shared_dir"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/anon_max_conn"
+            android:textColor="#ffffff"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/anon_max"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            android:maxLength="4"
+            android:paddingTop="10dp" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,4 +89,6 @@ Gemeldete Probleme und Verbesserungsvorschläge sind unter https://github.com/pp
     <string name="mixed_theme">Gemischtes Thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="anon_max_conn">Max. gleichzeitige Verbindungen</string>
+    <string name="manage_anon_label">Anonym verwalten…</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -143,5 +143,7 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="light_theme">Φωτεινό Θέμα</string>
     <string name="mixed_theme">Ανάμεικτο Θέμα</string>
 
+    <string name="anon_max_conn">Μέγιστες ταυτόχρονες συνδέσεις</string>
+    <string name="manage_anon_label">Διαχείριση ανώνυμων…</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,5 +166,7 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
     </string>
     <string name="write_external_storage_old_android_version_summary">En estos dispositivos, toda lo guardado está disponible utilizando la jerarquía de archivos.</string>
 
+    <string name="anon_max_conn">Conexiones simultáneas máximas</string>
+    <string name="manage_anon_label">Administrar anónimo…</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Thème mixte</string>
     <string name="app_theme">Thème...</string>
 
+    <string name="anon_max_conn">Nombre maximum de connexions simultanées</string>
+    <string name="manage_anon_label">Gérer les anonymes…</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -93,4 +93,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Tema misto</string>
     <string name="app_theme">Tema...</string>
 
+    <string name="anon_max_conn">Numero massimo di connessioni simultanee</string>
+    <string name="manage_anon_label">Gestisci anonimo…</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,4 +127,6 @@ https://github.com/ppareit/swiftp/issues を参照してください。\n\n
     <string name="mixed_theme">混合テーマ</string>
     <string name="app_theme">テーマ...</string>
 
+    <string name="anon_max_conn">最大同時接続数</string>
+    <string name="manage_anon_label">匿名で管理する…</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -95,4 +95,6 @@ van de volgende versie staan op https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Gemengd thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="anon_max_conn">Maximaal gelijktijdige verbindingen</string>
+    <string name="manage_anon_label">Beheer anoniem…</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -192,4 +192,6 @@ na stronie https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Na tych urządzeniach cały sklep jest dostępny przy użyciu hierarchii plików.</string>
 
+    <string name="anon_max_conn">Maksymalna liczba jednoczesnych połączeń</string>
+    <string name="manage_anon_label">Zarządzaj anonimowo…</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -108,4 +108,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Смешанная тема</string>
     <string name="app_theme">Тема...</string>
 
+    <string name="anon_max_conn">Максимальное количество одновременных подключений</string>
+    <string name="manage_anon_label">Управление анонимностью…</string>
 </resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -194,4 +194,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Në këto pajisje, e gjithë dyqani është në dispozicion duke përdorur hierarkinë e skedarit.</string>
 
+    <string name="anon_max_conn">Lidhjet maksimale të njëkohshme</string>
+    <string name="manage_anon_label">Menaxho anonim…</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -127,4 +127,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">микед Тема</string>
     <string name="app_theme">Тема...</string>
 
+    <string name="anon_max_conn">Максимално истовремене везе</string>
+    <string name="manage_anon_label">Управљајте анонимно…</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -165,5 +165,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">На цих пристроях вся пам\'ять доступна за допомогою ієрархії файлів.</string>
 
-
+    <string name="anon_max_conn">Максимальна кількість одночасних підключень</string>
+    <string name="manage_anon_label">Керувати анонімно…</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -82,4 +82,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建议。\n\n
     <string name="storage_warning">警告：当前存储暂不可用，您可能需要取消挂载。</string>
     <string name="widget_name">FTP Server Widget</string>
 
+    <string name="anon_max_conn">最大同时连接数</string>
+    <string name="manage_anon_label">管理匿名…</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -182,4 +182,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建議。\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">在這些裝置上，可以使用檔案階層標準來使用所有存儲空間。</string>
 
+    <string name="anon_max_conn">最大同時連線數</string>
+    <string name="manage_anon_label">管理匿名…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">On these devices, all store is available using the file hierarchy.</string>
 
+    <string name="anon_max_conn">Max simultaneous connections</string>
+    <string name="manage_anon_label">Manage anonymous…</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,11 +38,9 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
             android:key="manage_users"
             android:title="@string/manage_users_label" />
 
-        <CheckBoxPreference
-            android:defaultValue="@string/allow_anonymous_default"
-            android:key="allow_anonymous"
-            android:summary="@string/anonymous_summary"
-            android:title="@string/allow_anonymous_label" />
+        <Preference
+            android:key="manage_anon"
+            android:title="@string/manage_anon_label" />
 
         <PreferenceScreen
             android:key="appearance_screen"


### PR DESCRIPTION
#### Important - Requires pull requests to be applied before this:
- https://github.com/ppareit/swiftp/pull/205
- https://github.com/ppareit/swiftp/pull/217
- https://github.com/ppareit/swiftp/pull/227

Closes:
- https://github.com/ppareit/swiftp/issues/224
- https://github.com/ppareit/swiftp/issues/225

Anonymous improvements and fixes

Some quick notes:
- Moves enable anonymous setting into its own Activity and adds chroot selection and user set limit
- Fixes anonymous failure to work along side multi users scoped storage
- Connection login for limit determined in CmdPass where pre-existing anonymous pass check was done
- Tested on Android 6, Android 7.1.1, Android 14
- Adds logs to new logging to show current and max anonymous connected clients
- Deduplicated chroot picker as there would have been 3 duplications (but left orig alone)
- Blocked enabling anonymous via animation on anonymous chroot [to set chroot 1st] to avoid problems - scoped requires user chosen permission, and because of multi choice, a known static default can't be chosen so this is a good safety mechanism to keep the train on the correct track and avoid failures.
- Anonymous still has singular chroot here. Just that it is now user selectable
- Uses AtomicInteger for the limit count to promote better multi thread use
- Users with enabled anonymous on app update should be good (File gets set to orig location and scoped is blocked until chroot is set as a 2nd safety mechanism in the event the train gets on the tracks as it would be the wrong tracks for scoped)