### PR TITLE
Battery saver

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -25,14 +25,20 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.wifi.WifiManager;
 import android.net.wifi.WifiManager.WifiLock;
+import android.os.Build;
 import android.os.Environment;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
 import android.os.PowerManager;
 import android.os.SystemClock;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.Gravity;
 import android.widget.Toast;
@@ -74,17 +80,16 @@ public class FsService extends Service implements Runnable {
 
     protected ServerSocket listenSocket;
 
-    // The server thread will check this often to look for incoming
-    // connections. We are forced to use non-blocking accept() and polling
-    // because we cannot wait forever in accept() if we want to be able
-    // to receive an exit signal and cleanly exit.
-    public static final int WAKE_INTERVAL_MS = 1000; // milliseconds
-
-    private TcpListener wifiListener = null;
+    private TcpListener socketWatcher = null;
     private final List<SessionThread> sessionThreads = new ArrayList<>();
 
     private PowerManager.WakeLock wakeLock;
     private WifiLock wifiLock = null;
+
+    private static boolean connectionWakelockRunning = false;
+    static Handler connWakeLockHandler = null;
+    static Message connWakeLockMessage = null;
+    static boolean useConnWakeLocks = false;
 
 
     /**
@@ -187,6 +192,9 @@ public class FsService extends Service implements Runnable {
     public void onDestroy() {
         Log.i(TAG, "onDestroy() Stopping server");
         shouldExit = true;
+
+        endServer();
+
         if (serverThread == null) {
             Log.w(TAG, "Stopping with null serverThread");
             return;
@@ -211,17 +219,26 @@ public class FsService extends Service implements Runnable {
         } catch (IOException ignored) {
         }
 
-        if (wifiLock != null) {
-            Log.d(TAG, "onDestroy: Releasing wifi lock");
-            wifiLock.release();
-            wifiLock = null;
-        }
-        if (wakeLock != null) {
-            Log.d(TAG, "onDestroy: Releasing wake lock");
-            wakeLock.release();
-            wakeLock = null;
-        }
+        releaseWakelocks();
+
+        if (connWakeLockHandler != null) connWakeLockHandler.removeCallbacksAndMessages(null);
+        if (connWakeLockMessage != null) connWakeLockMessage = null;
+
         Log.d(TAG, "FTPServerService.onDestroy() finished");
+    }
+
+    private void endServer() {
+        terminateAllSessions();
+
+        if (socketWatcher != null) {
+            socketWatcher.quit();
+            socketWatcher = null;
+        }
+        shouldExit = false; // we handled the exit flag, so reset it to acknowledge
+        Log.d(TAG, "Exiting cleanly, returning from run()");
+
+        stopSelf();
+        sendBroadcast(new Intent(ACTION_STOPPED));
     }
 
     // This opens a listening socket on all interfaces.
@@ -252,51 +269,23 @@ public class FsService extends Service implements Runnable {
             return;
         }
 
-        // @TODO: when using ethernet, is it needed to take wifi lock?
-        takeWifiLock();
-        takeWakeLock();
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
+        final int batterySaver = Integer.parseInt(sp.getString("battery_saver", "1"));
+        if (batterySaver == 0) {
+            // @TODO: when using ethernet, is it needed to take wifi lock?
+            takeWifiLock();
+            takeWakeLock();
+        } else if (batterySaver == 1) {
+            useConnWakeLocks = true;
+            initializeConnWakeLocks();
+        }
 
         // A socket is open now, so the FTP server is started, notify rest of world
         Log.i(TAG, "Ftp Server up and running, broadcasting ACTION_STARTED");
         sendBroadcast(new Intent(ACTION_STARTED));
 
-        while (!shouldExit) {
-            if (wifiListener != null) {
-                if (!wifiListener.isAlive()) {
-                    Log.d(TAG, "Joining crashed wifiListener thread");
-                    try {
-                        wifiListener.join();
-                    } catch (InterruptedException ignored) {
-                    }
-                    wifiListener = null;
-                }
-            }
-            if (wifiListener == null) {
-                // Either our wifi listener hasn't been created yet, or has crashed,
-                // so spawn it
-                wifiListener = new TcpListener(listenSocket, this);
-                wifiListener.start();
-            }
-            try {
-                // TODO: think about using ServerSocket, and just closing
-                // the main socket to send an exit signal
-                Thread.sleep(WAKE_INTERVAL_MS);
-            } catch (InterruptedException e) {
-                Log.d(TAG, "Thread interrupted");
-            }
-        }
-
-        terminateAllSessions();
-
-        if (wifiListener != null) {
-            wifiListener.quit();
-            wifiListener = null;
-        }
-        shouldExit = false; // we handled the exit flag, so reset it to acknowledge
-        Log.d(TAG, "Exiting cleanly, returning from run()");
-
-        stopSelf();
-        sendBroadcast(new Intent(ACTION_STOPPED));
+        socketWatcher = new TcpListener(listenSocket, this);
+        socketWatcher.start();
     }
 
     private void terminateAllSessions() {
@@ -318,12 +307,13 @@ public class FsService extends Service implements Runnable {
      * CPU throttling. For these devices, we have a option to force the phone into a full
      * wake lock.
      */
-    private void takeWakeLock() {
+    public void takeWakeLock() {
         if (wakeLock == null) {
             PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
             if (FsSettings.shouldTakeFullWakeLock()) {
                 Log.d(TAG, "takeWakeLock: Taking full wake lock");
-                wakeLock = pm.newWakeLock(PowerManager.FULL_WAKE_LOCK, TAG);
+                // Note: FULL_WAKE_LOCK is deprecated, officially not recommended, and is actually worse.
+                wakeLock = pm.newWakeLock(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON, TAG);
             } else {
                 Log.d(TAG, "maybeTakeWakeLock: Taking partial wake lock");
                 wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
@@ -333,14 +323,84 @@ public class FsService extends Service implements Runnable {
         wakeLock.acquire();
     }
 
-    private void takeWifiLock() {
+    public void takeWifiLock() {
         Log.d(TAG, "takeWifiLock: Taking wifi lock");
         if (wifiLock == null) {
             WifiManager manager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
-            wifiLock = manager.createWifiLock(TAG);
+            if (Build.VERSION.SDK_INT >= 29) {
+                // Low is forced starting in Android 14 and starts use at Android 10.
+                wifiLock = manager.createWifiLock(WifiManager.WIFI_MODE_FULL_LOW_LATENCY, TAG);
+            } else {
+                wifiLock = manager.createWifiLock(TAG);
+            }
             wifiLock.setReferenceCounted(false);
         }
         wifiLock.acquire();
+    }
+
+    public void releaseWakelocks() {
+        if (wifiLock != null) {
+            Log.d(TAG, "onDestroy: Releasing wifi lock");
+            wifiLock.release();
+            wifiLock = null;
+        }
+        if (wakeLock != null) {
+            Log.d(TAG, "onDestroy: Releasing wake lock");
+            wakeLock.release();
+            wakeLock = null;
+        }
+        setConnWakelockNotRunning();
+    }
+
+    public boolean isConnWakelockRunning() {
+        return connectionWakelockRunning;
+    }
+
+    public void setConnWakelockNotRunning() {
+        //logging.appendLog("connection wakelocks (off)...");
+        connectionWakelockRunning = false;
+    }
+
+    public void setConnWakelockRunning() {
+        //logging.appendLog("connection wakelocks (on)...");
+        connectionWakelockRunning = true;
+    }
+
+    public void initializeConnWakeLocks() {
+        if (connWakeLockHandler != null) return;
+        connWakeLockHandler = new Handler(Looper.getMainLooper()) {
+            @Override
+            public void handleMessage(@androidx.annotation.NonNull Message msg) {
+                super.handleMessage(msg);
+                if (isConnWakelockRunning()) releaseWakelocks();
+            }
+        };
+    }
+
+    public void createConnWakeLock() {
+        if (!useConnWakeLocks) return;
+        if (connWakeLockMessage != null) {
+            connWakeLockHandler.removeCallbacksAndMessages(null);
+            connWakeLockMessage = null;
+        }
+        if (!isConnWakelockRunning()) {
+            takeWakeLock();
+            takeWifiLock();
+            setConnWakelockRunning();
+        }
+    }
+
+    /* Handle a delayed reaction to ending connection wakelocks.
+     * As its not possible to know when it will end since ftp client can quit and connect right back
+     * again, need to create a delayed reaction. A handler with a delayed message works well.
+     * */
+    public static void connWakelockEndHandler() {
+        if (!useConnWakeLocks) return;
+        if (connWakeLockMessage == null) {
+            //new Logging().appendLog("connection wakelocks to off in 10 minutes...\n\n\n");
+            connWakeLockMessage = connWakeLockHandler.obtainMessage();
+            connWakeLockHandler.sendMessageDelayed(connWakeLockMessage, 600000);
+        }
     }
 
     /**

--- a/app/src/main/java/be/ppareit/swiftp/FsSettings.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsSettings.java
@@ -138,6 +138,15 @@ public class FsSettings {
         return port;
     }
 
+    public static String getBatterySaverChoice(String val) {
+        final SharedPreferences sp = getSharedPreferences();
+        String s = sp.getString("battery_saver", "1");
+        if (val != null) s = val;
+        if (s.equals("0")) return  App.getAppContext().getString(R.string.bs_high);
+        if (s.equals("1")) return App.getAppContext().getString(R.string.bs_low);
+        return App.getAppContext().getString(R.string.bs_deep);
+    }
+
     public static boolean shouldTakeFullWakeLock() {
         final SharedPreferences sp = getSharedPreferences();
         return sp.getBoolean("stayAwake", false);

--- a/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/PreferenceFragment.java
@@ -161,6 +161,34 @@ public class PreferenceFragment extends android.preference.PreferenceFragment {
             writeExternalStoragePref.setSummary(getString(R.string.write_external_storage_old_android_version_summary));
         }
 
+        final ListPreference batterySaver = findPref("battery_saver");
+        // val 0 HIGH is always on wake locks + wake lock setting enabled (high battery, smooth)
+        // val 1 LOW is wake locks run only during client connection (low battery, some of both)
+        // val 2 DEEP is wake locks disabled (lowest battery use, a bit choppy)
+        final String s = batterySaver.getValue();
+        if (Integer.parseInt(s) > 1) {
+            wakelockPref.setChecked(false);
+            wakelockPref.setEnabled(false);
+        } else {
+            wakelockPref.setEnabled(true);
+        }
+        batterySaver.setTitle("Battery saver");
+        final String bSumSelection = FsSettings.getBatterySaverChoice(null) + '\n';
+        final String bSum = bSumSelection + getString(R.string.battery_saver_desc);
+        batterySaver.setSummary(bSum);
+        batterySaver.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (Integer.parseInt((String) newValue) > 1) {
+                wakelockPref.setChecked(false);
+                wakelockPref.setEnabled(false);
+            } else {
+                wakelockPref.setEnabled(true);
+            }
+            final String bSumSelection2 = FsSettings.getBatterySaverChoice(
+                    (String) newValue) + '\n';
+            final String bSum2 = bSumSelection2 + getString(R.string.battery_saver_desc);
+            batterySaver.setSummary(bSum2);
+            return true;
+        });
 
         ListPreference themePref = findPref("theme");
         themePref.setSummary(themePref.getEntry());

--- a/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/SessionThread.java
@@ -34,6 +34,7 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 
 import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.FsService;
 import be.ppareit.swiftp.FsSettings;
 
 public class SessionThread extends Thread {
@@ -256,6 +257,7 @@ public class SessionThread extends Thread {
             Cat.i("Connection was dropped");
         }
         closeSocket();
+        FsService.connWakelockEndHandler();
     }
 
     public void closeSocket() {

--- a/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
@@ -70,7 +70,7 @@ public class TcpListener extends Thread {
             }
         } catch (Exception e) {
             Log.d(TAG, "Exception in TcpListener");
-            ftpServerService.releaseWakelocks();
+            if (ftpServerService.isConnWakelockRunning()) ftpServerService.releaseWakelocks();
         }
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
@@ -48,15 +48,29 @@ public class TcpListener extends Thread {
     @Override
     public void run() {
         try {
+            Socket clientSocket;
             while (true) {
-                Socket clientSocket = listenSocket.accept();
+                try {
+                    clientSocket = listenSocket.accept(); // blocks loop until next connection
+                } catch (Exception e) {
+                    // call to close() on server off causes SocketException here with "Socket closed"
+                    final String msg = e.getMessage();
+                    if (msg != null && msg.contains("Socket closed")) {
+                        if (ftpServerService.isConnWakelockRunning()) ftpServerService.releaseWakelocks();
+                        return;
+                    }
+                    // Simple retry and fail back to next catch or continue on success
+                    clientSocket = listenSocket.accept();
+                }
                 Log.i(TAG, "New connection, spawned thread");
+                ftpServerService.createConnWakeLock();
                 SessionThread newSession = new SessionThread(clientSocket, new LocalDataSocket());
                 newSession.start();
                 ftpServerService.registerSessionThread(newSession);
             }
         } catch (Exception e) {
             Log.d(TAG, "Exception in TcpListener");
+            ftpServerService.releaseWakelocks();
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -89,4 +89,9 @@ Gemeldete Probleme und Verbesserungsvorschläge sind unter https://github.com/pp
     <string name="mixed_theme">Gemischtes Thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="battery_saver_setting_title">Batteriesparmodus</string>
+    <string name="battery_saver_desc">HINWEIS: Sie *müssen* den Server nach der Änderung manuell neu starten.</string>
+    <string name="bs_high">HOCH</string>
+    <string name="bs_low">NIEDRIG</string>
+    <string name="bs_deep">TIEF</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -143,5 +143,10 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="light_theme">Φωτεινό Θέμα</string>
     <string name="mixed_theme">Ανάμεικτο Θέμα</string>
 
+    <string name="battery_saver_setting_title">Εξοικονόμηση μπαταρίας</string>
+    <string name="battery_saver_desc">ΣΗΜΕΙΩΣΗ: *Πρέπει* να κάνετε μη αυτόματη επανεκκίνηση του διακομιστή μετά την αλλαγή.</string>
+    <string name="bs_high">ΥΨΗΛΟΣ</string>
+    <string name="bs_low">ΧΑΜΗΛΟΣ</string>
+    <string name="bs_deep">ΒΑΘΥΣ</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -166,5 +166,10 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
     </string>
     <string name="write_external_storage_old_android_version_summary">En estos dispositivos, toda lo guardado está disponible utilizando la jerarquía de archivos.</string>
 
+    <string name="battery_saver_setting_title">Ahorro de batería</string>
+    <string name="battery_saver_desc">NOTA: *Debe* reiniciar manualmente el servidor después de realizar el cambio.</string>
+    <string name="bs_high">ALTO</string>
+    <string name="bs_low">BAJO</string>
+    <string name="bs_deep">PROFUNDO</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,4 +148,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Thème mixte</string>
     <string name="app_theme">Thème...</string>
 
+    <string name="battery_saver_setting_title">Économiseur de batterie</string>
+    <string name="battery_saver_desc">REMARQUE : Vous *devez* redémarrer manuellement le serveur après la modification.</string>
+    <string name="bs_high">HAUT</string>
+    <string name="bs_low">FAIBLE</string>
+    <string name="bs_deep">PROFOND</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -93,4 +93,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Tema misto</string>
     <string name="app_theme">Tema...</string>
 
+    <string name="battery_saver_setting_title">Risparmio batteria</string>
+    <string name="battery_saver_desc">NOTA: *è necessario* riavviare manualmente il server dopo la modifica.</string>
+    <string name="bs_high">ALTO</string>
+    <string name="bs_low">BASSO</string>
+    <string name="bs_deep">PROFONDO</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -127,4 +127,9 @@ https://github.com/ppareit/swiftp/issues を参照してください。\n\n
     <string name="mixed_theme">混合テーマ</string>
     <string name="app_theme">テーマ...</string>
 
+    <string name="battery_saver_setting_title">バッテリーセーバー</string>
+    <string name="battery_saver_desc">注: 変更後はサーバーを手動で再起動する必要があります。</string>
+    <string name="bs_high">高い</string>
+    <string name="bs_low">低い</string>
+    <string name="bs_deep">深い</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -95,4 +95,9 @@ van de volgende versie staan op https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Gemengd thema</string>
     <string name="app_theme">Thema...</string>
 
+    <string name="battery_saver_setting_title">Batterij bespaarder</string>
+    <string name="battery_saver_desc">OPMERKING: U *moet* de server handmatig opnieuw opstarten na het wijzigen.</string>
+    <string name="bs_high">HOOG</string>
+    <string name="bs_low">LAAG</string>
+    <string name="bs_deep">DIEP</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -192,4 +192,9 @@ na stronie https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Na tych urządzeniach cały sklep jest dostępny przy użyciu hierarchii plików.</string>
 
+    <string name="battery_saver_setting_title">Program oszczędzający baterię</string>
+    <string name="battery_saver_desc">UWAGA: *musisz* ręcznie zrestartować serwer po zmianie.</string>
+    <string name="bs_high">WYSOKI</string>
+    <string name="bs_low">NISKI</string>
+    <string name="bs_deep">GŁĘBOKO</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -108,4 +108,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Смешанная тема</string>
     <string name="app_theme">Тема...</string>
 
+    <string name="battery_saver_setting_title">Экономия заряда батареи</string>
+    <string name="battery_saver_desc">ПРИМЕЧАНИЕ. После внесения изменений вы *должны* вручную перезапустить сервер.</string>
+    <string name="bs_high">ВЫСОКИЙ</string>
+    <string name="bs_low">НИЗКИЙ</string>
+    <string name="bs_deep">ГЛУБОКИЙ</string>
 </resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -194,4 +194,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">Në këto pajisje, e gjithë dyqani është në dispozicion duke përdorur hierarkinë e skedarit.</string>
 
+    <string name="battery_saver_setting_title">Kursuesi i baterisë</string>
+    <string name="battery_saver_desc">SHËNIM: *Duhet* të rinisni manualisht serverin pas ndryshimit.</string>
+    <string name="bs_high">I LARTË</string>
+    <string name="bs_low">I ULËT</string>
+    <string name="bs_deep">THELLË</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -126,5 +126,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="light_theme">лигхт Тема</string>
     <string name="mixed_theme">микед Тема</string>
     <string name="app_theme">Тема...</string>
-
+    <string name="battery_saver_setting_title">Уштеда батерије</string>
+    <string name="battery_saver_desc">НАПОМЕНА: *морате* ручно поново покренути сервер након промене.</string>
+    <string name="bs_high">ХИГХ</string>
+    <string name="bs_low">ЛОВ</string>
+    <string name="bs_deep">ДУБОКО</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -165,5 +165,9 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">На цих пристроях вся пам\'ять доступна за допомогою ієрархії файлів.</string>
 
-
+    <string name="battery_saver_setting_title">Економія батареї</string>
+    <string name="battery_saver_desc">ПРИМІТКА. Ви *потрібно* вручну перезапустити сервер після зміни.</string>
+    <string name="bs_high">ВИСОКА</string>
+    <string name="bs_low">НИЗЬКИЙ</string>
+    <string name="bs_deep">ГЛИБОКИЙ</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -82,4 +82,9 @@ https://github.com/ppareit/swiftp/issues 提交您的建议。\n\n
     <string name="storage_warning">警告：当前存储暂不可用，您可能需要取消挂载。</string>
     <string name="widget_name">FTP Server Widget</string>
 
+    <string name="battery_saver_setting_title">省电</string>
+    <string name="battery_saver_desc">注意：更改后您*必须*手动重新启动服务器。</string>
+    <string name="bs_high">高的</string>
+    <string name="bs_low">低的</string>
+    <string name="bs_deep">深的</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -182,4 +182,9 @@ https://github.com/ppareit/swiftp/issues 提交您的建議。\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">在這些裝置上，可以使用檔案階層標準來使用所有存儲空間。</string>
 
+    <string name="battery_saver_setting_title">省電</string>
+    <string name="battery_saver_desc">注意：更改後您*必須*手動重新啟動伺服器。</string>
+    <string name="bs_high">高的</string>
+    <string name="bs_low">低的</string>
+    <string name="bs_deep">深的</string>
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -11,4 +11,16 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+
+    <string-array name="pref_list_battery_saver_titles">
+    <item>@string/bs_high</item>
+    <item>@string/bs_low</item>
+    <item>@string/bs_deep</item>
+    </string-array>
+
+    <string-array name="pref_list_battery_saver_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -193,4 +193,10 @@ https://github.com/ppareit/swiftp/issues .\n\n
     </string>
     <string name="write_external_storage_old_android_version_summary">On these devices, all store is available using the file hierarchy.</string>
 
+    <!-- since 3.1 -->
+    <string name="battery_saver_setting_title">Battery Saver</string>
+    <string name="battery_saver_desc">NOTE: You *must* manually restart server after changing.</string>
+    <string name="bs_high">HIGH</string>
+    <string name="bs_low">LOW</string>
+    <string name="bs_deep">DEEP</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -77,6 +77,16 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
                 android:defaultValue="@string/writeExternalStorage_default"
                 android:key="writeExternalStorage"
                 android:title="@string/writeExternalStorage_label" />
+
+            <ListPreference
+                android:defaultValue="0"
+                android:entries="@array/pref_list_battery_saver_titles"
+                android:entryValues="@array/pref_list_battery_saver_values"
+                android:key="battery_saver"
+                android:dialogTitle="@string/battery_saver_setting_title"
+                android:title="@string/battery_saver_setting_title"
+                android:summary="@string/battery_saver_desc"/>
+
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
Closes
- https://github.com/ppareit/swiftp/issues/223

Battery saver

Some quick notes:
- Idle battery drops off of Android battery chart to <0.1% and won't show up in a day of pure idle (pre pull request my device was ~0.3-0.6% per every 2 hours)
- Default set to HIGH (high battery use) to maintain backwards compat during app updates
- Android battery chart can be wrong as it is currently on my Android 14 device. So be aware. Battery usage difference above was seen before the chart broke.
- Just seen past 24 hours, Android 14's app clear data can result in older app code showing up so that can potentially mess up your ideas of how the app battery use is working. Older code (not related but I'm adding this note here) showed up that was removed for 11 hours and was _definitely_ not in the app before clearing. I checked and there was no way for me to cause it not even accidentally. Be aware.
- Added advanced preference to choose from full wake locks, connection only wake locks, and no wake locks
- Deep (no wake locks) also disables cpu wake lock preference setting
- Tested on Android 6, Android 7.1.1, Android 14
- Previous cpu full wake lock (now set using battery saver HIGH + full cpu wakelock setting enabled) use didn't actually work on Android 14 (new way does and recommended by Android) - tested many combinations and narrowed to this.
- New full wake locks will be very smooth all the time (tested 10 days straight with fully smooth connections)
- Removed a loop running for no reason (much testing has been done without it and showing zero problems)
- Changed name of wifiListener to socketWatcher as it literally had zero to do with wifi and is involved in the code changes here
- Various exit, crash testing done
- Long time running purely in background done
- Connection wake locks may delay before wake lock is turned on but will be smooth during connection provided too that full cpu wake lock is also enabled.
- Disabled wake locks will have delays and clients would need to have increased timeouts set or will timeout roughly 1-2x per several days. Idle battery usage will be super low and many may find it good enough for their needs.
- Naturally cannot workaround devices that break apps running in the background (devices with bad OS behavior)
- Many devices have their own setting to allow apps to keep running in the background and that needs to be set outside of the app and by the user
- Connection wake locks are delayed 10 minutes to off after client quit to allow time for clients to quit and connect again as at times they do this and it will keep the connection fully smooth. Delay reset if a client reconnects.
- Connection wake locks also have the super low idle battery use but may use more battery during connections.
- Super low idle battery use is fantastic. **I can't emphasize enough how much better it is** :)

#### Other notes:

Issues seen with causes noted (more causes can exist):

Connection timed out
 - In advanced settings, set battery saver to HIGH and also enable full cpu wakelock setting OR don't do either of those but increase client timeout if the client offers a setting to do so (not all do).
- Write external storage permission in the app needs to be re-obtained for the user the client is trying to connect to
- Client machine suspended/hibernated during connection

No route to host
- Client tries before the client OS brings up the network connection

Examples to adjust Android OS battery settings for apps:

- Android 6: Battery > Battery Optimization > set app to not optimized
- Newer Samsung devices eg Android 12-14: Android's settings for the app > battery > set to unrestricted

#### Original info I wrote to figure out what was going on with the loop I removed in FsService run() that I didn't want to leave commented in the code for this pull request.

So what does actually happen after this point here...
  1. new TcpListener() aka server + thread
  2. Gets puts back in here at registerSessionThread() into sessionThreads holder
  3. Because of Service sticking around in the bg, it is therefore kept around and not lost or GC'd
  4. Therefore socket, etc stays open due to Service, server on, etc.
  5. new TcpListener() is then removed each time registerSessionThread() is called in TcpListener
      which it removes but also adds so its always there and not lost. registerSessionThread() is
      mostly remove/cleanup so its a bit oddly named. Don't get thrown off looking at it.
  6. new TcpListener() sticks around (and also doesn't loop thousand times per sec) as
      listenSocket.accept() blocks until new connection is made. Has no timeout, etc. Thus,
      everything stays working, socket stays open, clients can connect, etc.
  7. The loop in TcpListener with the .accept() basically keeps everything going. Everything, pauses
      while its blocking. Once it receives the next connection is made, everything loops again. Repeat.
  8. Repeats until server is turned off (on/off toggle switch) and then onDestroy is called and
      cleans everything up. When server is toggled on again, we arrive back here.

However, removal tested without a single issue. Tested for months, tested against original during any seen problems to the same result. Zero difference found except for lower battery use :)

Again, no loop + full wakelocks + battery saver at HIGH with app running in bg (no foreground use at all) had super smooth connections with 0 connection failures or delays for 10 days straight. Logs for all connections watched with times visible. Connections in UIs always heavily watched. Android 14.