### PR TITLE
Battery saver fix

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -313,7 +313,7 @@ public class FsService extends Service implements Runnable {
             if (FsSettings.shouldTakeFullWakeLock()) {
                 Log.d(TAG, "takeWakeLock: Taking full wake lock");
                 // Note: FULL_WAKE_LOCK is deprecated, officially not recommended, and is actually worse.
-                wakeLock = pm.newWakeLock(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON, TAG);
+                wakeLock = pm.newWakeLock(PowerManager.FULL_WAKE_LOCK, TAG);
             } else {
                 Log.d(TAG, "maybeTakeWakeLock: Taking partial wake lock");
                 wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);


### PR DESCRIPTION
Sorry, need to revert to old full wake lock flag for now as I made a boo boo from looking at the popup documentation along the way. The keep screen flag on doesn't actually work here even though the wake lock is created and isHeld() is true and the popup documentation reads like it does.

I can change this here after FTPS pull request (soon to have that ready) or change it later... back again to the FLAG_KEEP_SCREEN_ON. When I tested it, quite sure it was quickly using a temporary bump of an Activity to static. That doesn't work for release though.

Need to decide on a way of using an Activity with it without static. Might take some time. I'd rather revert this for now until I figure that out. Although, technically, a static handler in the Activity class can go to non-static stuff so perhaps that will work and is quick. But, then again, want to do more testing on that to make sure too so it doesn't need another change.