### PR TITLE
FTPS along with everything to use it.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.jetbrains:annotations:23.0.0'
     implementation 'androidx.work:work-runtime:2.9.0'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06' // Used for EncryptedSharedPreferences
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,10 +43,12 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
     <application
         android:name="be.ppareit.swiftp.App"
         android:allowBackup="true"
+        android:fullBackupContent="@xml/backup_rules"
         android:banner="@drawable/banner"
         android:requestLegacyExternalStorage="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/swiftp_name">
+        android:label="@string/swiftp_name"
+        android:dataExtractionRules="@xml/data_extraction_rules">
 
         <activity
             android:name="be.ppareit.swiftp.gui.MainActivity"

--- a/app/src/main/java/be/ppareit/swiftp/gui/FsNotification.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/FsNotification.java
@@ -51,12 +51,10 @@ public class FsNotification {
         // get ip address
         InetAddress address = FsService.getLocalInetAddress();
         String ipText;
-        if (address == null) {
-            ipText = "-";
-        } else {
-            ipText = "ftp://" + address.getHostAddress() + ":"
-                    + FsSettings.getPortNumber() + "/";
-        }
+        if (address == null) ipText = "-";
+        else ipText = "ftp://" + address.getHostAddress() + ":" + FsSettings.getPortNumber();
+        if (FsSettings.isImplicitUsed()) ipText += ", " + FsSettings.getPortNumberImplicit();
+        ipText += "/";
 
         // Instantiate a Notification
         int icon = R.mipmap.notification;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdAUTH.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdAUTH.java
@@ -1,0 +1,60 @@
+/*
+Copyright 2009 David Revell
+
+This file is part of SwiFTP.
+
+SwiFTP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SwiFTP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package be.ppareit.swiftp.server;
+
+import android.util.Log;
+
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.FTPSSockets;
+
+public class CmdAUTH extends FtpCmd implements Runnable {
+    private static final String TAG = CmdPROT.class.getSimpleName();
+    protected String input;
+
+    public CmdAUTH(SessionThread sessionThread, String input) {
+        super(sessionThread);
+        this.input = input;
+    }
+
+    @Override
+    public void run() {
+        Log.d(TAG, "AUTH executing");
+        String param = getParameter(input);
+
+        if (param.contains("TLS")) {
+            sessionThread.writeString("234 AUTH command OK. Initializing TLS connection.\r\n");
+            sessionThread.cmdSSLAuthSocket = new FTPSSockets().createAuthSocket("TLS", sessionThread.cmdSocket);
+        } else if (param.contains("SSL")) {
+            if (FsSettings.useSSL()) {
+                sessionThread.writeString("234 AUTH command OK. Initializing SSL connection.\r\n");
+                sessionThread.cmdSSLAuthSocket = new FTPSSockets().createAuthSocket("SSL", sessionThread.cmdSocket);
+            }
+        }
+
+        if (sessionThread.cmdSSLAuthSocket == null) {
+            // After this, the connection tested good with being dropped and socket closed
+            sessionThread.writeString("431 AUTH failed\r\n");
+            Log.d(TAG, "AUTH failed");
+            return;
+        }
+
+        Log.d(TAG, "AUTH success");
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractStore.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdAbstractStore.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.Util;
 import be.ppareit.swiftp.utils.FileUtil;
 import be.ppareit.swiftp.MediaUpdater;
@@ -154,12 +155,16 @@ abstract public class CmdAbstractStore extends FtpCmd {
                 errString = "451 Unable to seek in file to append\r\n";
                 break storing;
             }
+            final boolean early150 = FsSettings.isEarly150Enabled();
+            if (early150) {
+                sessionThread.writeString("150 Data socket ready\r\n");
+            }
             if (!sessionThread.openDataSocket()) {
                 errString = "425 Couldn't open data socket\r\n";
                 break storing;
             }
             Cat.d("Data socket ready");
-            sessionThread.writeString("150 Data socket ready\r\n");
+            if (!early150) sessionThread.writeString("150 Data socket ready\r\n");
             byte[] buffer = new byte[SessionThread.DATA_CHUNK_SIZE];
 
             int numRead;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdEPRT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdEPRT.java
@@ -1,0 +1,82 @@
+/*
+Copyright 2009 David Revell
+
+This file is part of SwiFTP.
+
+SwiFTP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SwiFTP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package be.ppareit.swiftp.server;
+
+import android.util.Log;
+
+import java.net.Inet6Address;
+import java.net.NetworkInterface;
+
+public class CmdEPRT extends FtpCmd implements Runnable {
+    private static final String TAG = CmdEPRT.class.getSimpleName();
+    protected String input;
+
+    public CmdEPRT(SessionThread sessionThread, String input) {
+        super(sessionThread);
+        this.input = input;
+    }
+
+    @Override
+    public void run() {
+        Log.d(TAG, "EPRT executing");
+        String param = getParameter(input);
+
+        if (param.isEmpty()) {
+            Log.e(TAG, "Bad EPRT command");
+            sessionThread.writeString("500 Empty command is invalid\r\n");
+            return;
+        }
+
+        // TODO implement IPv4
+        if (param.contains("|1|")) {
+            // IPv4 isn't implemented fpr EPRT
+            sessionThread.writeString("502 IPv4 command not implemented.\r\n");
+            return;
+        }
+
+        // From client eg EPRT |2|IPv6Address|Port|
+        //  |1| is IPv4, |2| is IPv6
+        //  IPv6Address is the address to use with the socket
+        //  Port is the port to use with the socket
+        String addressString = param.replace("|2|", "");
+        String portString = addressString.substring(addressString.indexOf("|") + 1);
+        portString = portString.replace("|", "");
+        addressString = addressString.substring(0, addressString.indexOf("|"));
+        addressString = addressString.replace(portString, "");
+
+        try {
+            String a1 = addressString.replaceFirst("/", "");
+            byte[] addr = Inet6Address.getByName(a1).getAddress();
+            NetworkInterface ni = NetworkInterface.getByInetAddress(sessionThread.getDataSocketPasvIp());
+            // Scope ID required for IPv6 link local address
+            Inet6Address inet6Address = Inet6Address.getByAddress(a1, addr, ni);
+            sessionThread.onEprt(inet6Address, Integer.parseInt(portString));
+        } catch (Exception e) {
+            // There was a problem opening a port
+            Log.e(TAG, "Failed to open port:" + portString + ", " + addressString + ", " + e.getMessage());
+            sessionThread.writeString("500 Failed to open port\r\n");
+            return;
+        }
+
+        sessionThread.writeString("200 EPRT OK\r\n");
+        sessionThread.setEprtEnabled(true);
+        Log.d(TAG, "EPRT success");
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdEPSV.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdEPSV.java
@@ -1,0 +1,62 @@
+/*
+Copyright 2009 David Revell
+
+This file is part of SwiFTP.
+
+SwiFTP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SwiFTP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package be.ppareit.swiftp.server;
+
+import android.util.Log;
+
+import java.net.InetAddress;
+
+public class CmdEPSV extends FtpCmd implements Runnable {
+    private static final String TAG = CmdEPSV.class.getSimpleName();
+    protected String input;
+
+    public CmdEPSV(SessionThread sessionThread, String input) {
+        super(sessionThread);
+        this.input = input;
+    }
+
+    @Override
+    public void run() {
+        Log.d(TAG, "EPSV executing");
+        String param = getParameter(input);
+
+        if (!param.isEmpty()) {
+            sessionThread.writeString("500 Invalid command\r\n");
+            Log.d(TAG, "EPSV invalid command: " + param);
+            return;
+        }
+
+        int port;
+        InetAddress address;
+        address = sessionThread.getDataSocketPasvIp();
+        // Socket for EPSV requires the address of the device that Swiftp is running on.
+        if ((port = sessionThread.onEpsv(address)) == 0) {
+            // There was a problem opening a port
+            Log.e(TAG, "Failed to open port");
+            sessionThread.writeString("500 Failed to open port\r\n");
+            return;
+        }
+
+        final String responseString = "229 Entering Extended Passive Mode (|||" + port + "|)\r\n";
+        sessionThread.writeString(responseString);
+        sessionThread.setEpsvEnabled(true);
+        Log.d(TAG, "EPSV successful.");
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdFEAT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdFEAT.java
@@ -21,6 +21,9 @@ package be.ppareit.swiftp.server;
 
 import android.util.Log;
 
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.Logging;
+
 public class CmdFEAT extends FtpCmd implements Runnable {
     private static final String TAG = CmdFEAT.class.getSimpleName();
 
@@ -30,6 +33,13 @@ public class CmdFEAT extends FtpCmd implements Runnable {
 
     @Override
     public void run() {
+
+        if (FsSettings.isFeatDisabled()) {
+            new Logging().appendLog("FEAT is disabled");
+            sessionThread.writeString("502 Command not implemented\r\n");
+            return;
+        }
+
         Log.d(TAG, "run: Giving FEAT");
         sessionThread.writeString("211-Features supported by FTP Server\r\n");
         sessionThread.writeString(" UTF8\r\n");
@@ -44,6 +54,9 @@ public class CmdFEAT extends FtpCmd implements Runnable {
         sessionThread.writeString(" HASH MD5;SHA-1;SHA-256;SHA-384;SHA-512\r\n");
         sessionThread.writeString(" REST STREAM\r\n");
         sessionThread.writeString(" RANG STREAM\r\n");
+        sessionThread.writeString(" AUTH TLS\r\n");
+        sessionThread.writeString(" PBSZ\r\n");
+        sessionThread.writeString(" PROT\r\n");
         sessionThread.writeString("211 End\r\n");
         Log.d(TAG, "run: Gave FEAT");
     }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPASS.java
@@ -27,6 +27,7 @@ import be.ppareit.swiftp.App;
 import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.Util;
 import be.ppareit.swiftp.utils.AnonymousLimit;
+import be.ppareit.swiftp.utils.IPSecurity;
 import be.ppareit.swiftp.utils.Logging;
 
 public class CmdPASS extends FtpCmd implements Runnable {
@@ -87,6 +88,7 @@ public class CmdPASS extends FtpCmd implements Runnable {
             Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack
             sessionThread.writeString("500 Login incorrect.\r\n");
             sessionThread.authAttempt( false);
+            IPSecurity.putIPFail(sessionThread.getRemoteAddress());
         } else if (user.getPassword().equals(attemptPassword)) {
             Log.i(TAG, "User " + user.getUsername() + " password verified");
             sessionThread.writeString("230 Access granted\r\n");
@@ -100,6 +102,7 @@ public class CmdPASS extends FtpCmd implements Runnable {
             Util.sleepIgnoreInterrupt(1000); // sleep to foil brute force attack
             sessionThread.writeString("530 Login incorrect.\r\n");
             sessionThread.authAttempt(false);
+            IPSecurity.putIPFail(sessionThread.getRemoteAddress());
         }
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPASV.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPASV.java
@@ -34,6 +34,11 @@ public class CmdPASV extends FtpCmd implements Runnable {
     public void run() {
         String cantOpen = "502 Couldn't open a port\r\n";
         Log.d(TAG, "PASV running");
+        if (sessionThread.isEpsvEnabled()) {
+            Log.e(TAG, "EPSV already in use.");
+            sessionThread.writeString("500 EPSV already in use.\r\n");
+            return;
+        }
         int port;
         if ((port = sessionThread.onPasv()) == 0) {
             // There was a problem opening a port

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPBSZ.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPBSZ.java
@@ -21,31 +21,25 @@ package be.ppareit.swiftp.server;
 
 import android.util.Log;
 
-import be.ppareit.swiftp.FsSettings;
-import be.ppareit.swiftp.utils.Logging;
+public class CmdPBSZ extends FtpCmd implements Runnable {
+    private static final String TAG = CmdPBSZ.class.getSimpleName();
+    protected String input;
 
-public class CmdSYST extends FtpCmd implements Runnable {
-    private static final String TAG = CmdSYST.class.getSimpleName();
-
-    // This is considered a safe response to the SYST command, see
-    // http://cr.yp.to/ftp/syst.html
-    public static final String response = "215 UNIX Type: L8\r\n";
-
-    public CmdSYST(SessionThread sessionThread, String input) {
+    public CmdPBSZ(SessionThread sessionThread, String input) {
         super(sessionThread);
+        this.input = input;
     }
 
     @Override
     public void run() {
+        Log.d(TAG, "PBSZ executing");
+        String param = getParameter(input);
 
-        if (FsSettings.isSystDisabled()) {
-            new Logging().appendLog("SYST is disabled");
-            sessionThread.writeString("502 Command not implemented\r\n");
-            return;
-        }
+        if (!param.equals("0")) sessionThread.writeString("500 Invalid command\r\n");
 
-        Log.d(TAG, "SYST executing");
-        sessionThread.writeString(response);
-        Log.d(TAG, "SYST finished");
+        sessionThread.setPbszEnabled(true);
+        sessionThread.writeString("200 PBSZ command OK\r\n");
+
+        Log.d(TAG, "PBSZ success");
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPORT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPORT.java
@@ -56,6 +56,11 @@ public class CmdPORT extends FtpCmd implements Runnable {
                     break mainBlock;
                 }
             }
+            if (sessionThread.isEprtEnabled()) {
+                Log.e(TAG, "Failed to use PORT: EPRT already in use.");
+                sessionThread.writeString("500 EPRT already in use.\r\n");
+                break mainBlock;
+            }
             byte[] ipBytes = new byte[4];
             for (int i = 0; i < 4; i++) {
                 try {

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdPROT.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdPROT.java
@@ -1,0 +1,53 @@
+/*
+Copyright 2009 David Revell
+
+This file is part of SwiFTP.
+
+SwiFTP is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+SwiFTP is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package be.ppareit.swiftp.server;
+
+import android.util.Log;
+
+public class CmdPROT extends FtpCmd implements Runnable {
+    private static final String TAG = CmdPROT.class.getSimpleName();
+    protected String input;
+
+    public CmdPROT(SessionThread sessionThread, String input) {
+        super(sessionThread);
+        this.input = input;
+    }
+
+    @Override
+    public void run() {
+        Log.d(TAG, "PROT executing");
+        String param = getParameter(input);
+
+        if (!sessionThread.isPbszEnabled()) {
+            sessionThread.writeString("500 Failure: PBSZ command was not issued\r\n");
+            return;
+        }
+
+        switch (param) {
+            case "P" -> sessionThread.writeString("200 PROT command OK\r\n");
+            case "C" -> sessionThread.writeString("536 Protection level not supported\r\n");
+            case "S" -> sessionThread.writeString("536 Protection level not supported\r\n");
+            case "E" -> sessionThread.writeString("536 Protection level not supported\r\n");
+            default -> sessionThread.writeString("502 Command not recognized\r\n");
+        }
+
+        Log.d(TAG, "PROT success");
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdRETR.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.FsSettings;
 import be.ppareit.swiftp.Util;
 import be.ppareit.swiftp.utils.FileUtil;
 
@@ -87,6 +88,7 @@ public class CmdRETR extends FtpCmd implements Runnable {
                 }
                 byte[] buffer = new byte[SessionThread.DATA_CHUNK_SIZE];
                 int bytesRead;
+                if (FsSettings.isEarly150Enabled()) sessionThread.writeString("150 Sending file\r\n");
                 if (sessionThread.openDataSocket()) {
                     Cat.d("RETR opened data socket");
                 } else {
@@ -94,7 +96,7 @@ public class CmdRETR extends FtpCmd implements Runnable {
                     Cat.i("Error in initDataSocket()");
                     break mainblock;
                 }
-                sessionThread.writeString("150 Sending file\r\n");
+                if (!FsSettings.isEarly150Enabled()) sessionThread.writeString("150 Sending file\r\n");
                 if (sessionThread.isBinaryMode()) { // RANG is supported only in binary mode.
                     Cat.d("Transferring in binary mode");
                     long offset = 0L;

--- a/app/src/main/java/be/ppareit/swiftp/server/CmdUSER.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/CmdUSER.java
@@ -21,6 +21,8 @@ package be.ppareit.swiftp.server;
 
 import android.util.Log;
 
+import be.ppareit.swiftp.utils.IPSecurity;
+
 public class CmdUSER extends FtpCmd implements Runnable {
     private static final String TAG = CmdUSER.class.getSimpleName();
 
@@ -38,6 +40,7 @@ public class CmdUSER extends FtpCmd implements Runnable {
         String userName = FtpCmd.getParameter(input);
         if (!userName.matches("[A-Za-z0-9]+")) {
             sessionThread.writeString("530 Invalid username\r\n");
+            IPSecurity.putIPFail(sessionThread.getRemoteAddress());
             return;
         }
         sessionThread.writeString("331 Send password\r\n");

--- a/app/src/main/java/be/ppareit/swiftp/server/LocalDataSocket.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/LocalDataSocket.java
@@ -22,25 +22,39 @@ package be.ppareit.swiftp.server;
 import android.util.Log;
 
 import java.io.IOException;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
+import java.util.Arrays;
+import java.util.Random;
+
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
 
 import be.ppareit.swiftp.FsService;
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.FTPSSockets;
+import be.ppareit.swiftp.utils.Logging;
 
 public class LocalDataSocket {
     private static final String TAG = LocalDataSocket.class.getSimpleName();
 
     private static final int SO_TIMEOUT_MS = 30000; // socket timeout millis
-    private static final int TCP_CONNECTION_BACKLOG = 5;
-
+    public static final int TCP_CONNECTION_BACKLOG = 5;
 
     // Listener socket used for PASV mode
     ServerSocket server = null;
+    SSLServerSocket sslServer = null;
     // Remote IP & port information used for PORT mode
-    private InetAddress remoteAddress;
+    private InetAddress remoteAddress = null;
     private int remotePort;
-    private boolean isPasvMode = true;
+    private Inet6Address remote6Address = null;
+    private int remote6Port;
+    private final Logging logging = new Logging();
+
+    private final FTPSSockets ftpsSockets = new FTPSSockets();
 
     public LocalDataSocket() {
         clearState();
@@ -55,26 +69,82 @@ public class LocalDataSocket {
             try {
                 server.close();
             } catch (IOException e) {
+                //
             }
+            server = null;
         }
-        server = null;
+        if (sslServer != null) {
+            try {
+                sslServer.close();
+            } catch (IOException e) {
+                //
+            }
+            sslServer = null;
+        }
         remoteAddress = null;
         remotePort = 0;
+        remote6Address = null;
+        remote6Port = 0;
         Log.d(TAG, "State cleared");
     }
 
-    public int onPasv() {
+    public int onPasv(boolean ssl) {
         clearState();
         try {
             // Listen on any port (port parameter 0)
-            server = new ServerSocket(0, TCP_CONNECTION_BACKLOG);
+            if (ssl) {
+                sslServer = ftpsSockets.createSSLServerSocket();
+                Log.d(TAG, "Data socket pasv() listen successful");
+                return sslServer.getLocalPort();
+            }
+            server = new ServerSocket(getNewPort(), TCP_CONNECTION_BACKLOG);
             Log.d(TAG, "Data socket pasv() listen successful");
             return server.getLocalPort();
-        } catch (IOException e) {
+        } catch (Exception e) {
             Log.e(TAG, "Data socket creation error");
             clearState();
             return 0;
         }
+    }
+
+    public int onEpsvPlain(InetAddress address) {
+        try {
+            server = new ServerSocket(getNewPort(), TCP_CONNECTION_BACKLOG, address);
+            Log.d(TAG, "Data socket pasv() listen successful");
+            return server.getLocalPort();
+        } catch (Exception e) {
+            //
+        }
+        return 0;
+    }
+
+    public int onEpsv(InetAddress address, boolean ssl) {
+        clearState();
+        if (ssl) {
+            try {
+                // Listen on any port (port parameter 0)
+                sslServer = ftpsSockets.createSSLServerSocketEpsv(address);
+                Log.d(TAG, "Data socket epsv() listen successful");
+                return sslServer.getLocalPort();
+            } catch (Exception e) {
+                Log.e(TAG, "Data socket creation error");
+                logging.appendLog("Data socket creation ex: " + e.getMessage());
+                clearState();
+                return 0;
+            }
+        }
+        return onEpsvPlain(address);
+    }
+
+    public static int getNewPort() {
+        int newPort = 0;
+        final int portRangeLow = FsSettings.getPortRangeLow();
+        final int portRangeHigh = FsSettings.getPortRangeHigh();
+        if (portRangeLow != 0 || portRangeHigh != 0) {
+            int i = new Random().nextInt(portRangeHigh - portRangeLow);
+            newPort = portRangeLow + i;
+        }
+        return newPort;
     }
 
     public boolean onPort(InetAddress remoteAddress, int remotePort) {
@@ -84,7 +154,100 @@ public class LocalDataSocket {
         return true;
     }
 
+    public void onEprt(Inet6Address remoteAddress, int remotePort) {
+        clearState();
+        this.remote6Address = remoteAddress;
+        this.remote6Port = remotePort;
+    }
+
     public Socket onTransfer() {
+        return plain();
+    }
+
+    public SSLSocket onTransferSSL() {
+        return ssl();
+    }
+
+    private SSLSocket ssl() {
+        if (sslServer == null) {
+            // We're in PORT mode (not PASV)
+            if ((remoteAddress == null || remotePort == 0) && (remote6Address == null || remote6Port == 0)) {
+                Log.i(TAG, "PORT mode but not initialized correctly");
+                clearState();
+                return null;
+            }
+            SSLSocket socket;
+            try {
+                if (remote6Address != null) socket = ftpsSockets.createSSLSocket6(remote6Address, remote6Port);
+                else socket = ftpsSockets.createSSLSocket(remoteAddress, remotePort);
+            } catch (Exception e) {
+                if (remote6Address != null) {
+                    Log.i(TAG, "Couldn't open PORT data socket to: " + remote6Address.toString()
+                            + ":" + remote6Port);
+                } else {
+                    Log.i(TAG, "Couldn't open PORT data socket to: " + remoteAddress.toString()
+                            + ":" + remotePort);
+                }
+                clearState();
+                return null;
+            }
+            socket.addHandshakeCompletedListener(event -> {
+                logging.appendLog("Handshake completed");
+                try {
+                    event.getSocket().setSoTimeout(0);
+                } catch (SocketException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            logging.appendLog("Begin FTPS handshake");
+            try {
+                socket.setSoTimeout(30000);
+                socket.startHandshake();
+            } catch (IOException e) {
+                return null;
+            }
+            return socket;
+        } else {
+            // We're in PASV mode (not PORT)
+            final SSLSocket socket;
+            try {
+                sslServer.setSoTimeout(30000);
+                socket = (SSLSocket) sslServer.accept();
+                sslServer.setSoTimeout(0);
+                socket.setTcpNoDelay(true);
+                changeSocketTimeout(socket, 30000); // require this before handshake (see catch block)
+                socket.addHandshakeCompletedListener(event -> {
+                    logging.appendLog("Handshake completed");
+                    changeSocketTimeout(socket, 0);
+                });
+                logging.appendLog("Begin FTPS handshake");
+                socket.startHandshake();
+            } catch (Exception e) {
+                // Confirmed that some clients will timeout on first use of data connection so do
+                // a handshake and find out right here and now.
+                if (remoteAddress != null) {
+                    Log.i(TAG, "Couldn't open PORT data socket to: " + remoteAddress.toString()
+                            + ":" + remotePort);
+                }
+                clearState();
+                return null;
+            }
+            clearState();
+            return socket; // will be null if error occurred
+        }
+    }
+
+    private void changeSocketTimeout(SSLSocket socket, int time) {
+        // Timeout is useful for handshake failures.
+        // Timeout must be 0 on handshake completion(!) or else randomly quits with enough work.
+        try {
+            socket.setSoTimeout(time);
+        } catch (SocketException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Socket plain() {
         if (server == null) {
             // We're in PORT mode (not PASV)
             if (remoteAddress == null || remotePort == 0) {
@@ -116,10 +279,12 @@ public class LocalDataSocket {
             // We're in PASV mode (not PORT)
             Socket socket = null;
             try {
+                server.setSoTimeout(30000);
                 socket = server.accept();
+                server.setSoTimeout(0);
                 Log.d(TAG, "onTransfer pasv accept successful");
             } catch (Exception e) {
-                Log.i(TAG, "Exception accepting PASV socket");
+                Log.i(TAG, "Exception accepting PASV socket: " + Arrays.toString(e.getStackTrace()));
                 socket = null;
             }
             clearState();

--- a/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
+++ b/app/src/main/java/be/ppareit/swiftp/server/TcpListener.java
@@ -21,17 +21,34 @@ package be.ppareit.swiftp.server;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketException;
 
 import android.util.Log;
+
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLSocket;
+
 import be.ppareit.swiftp.FsService;
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.utils.IPSecurity;
+import be.ppareit.swiftp.utils.Logging;
 
 public class TcpListener extends Thread {
     private static final String TAG = TcpListener.class.getSimpleName();
 
     ServerSocket listenSocket;
+    SSLServerSocket listenSSLSocket;
     FsService ftpServerService;
 
-    public TcpListener(ServerSocket listenSocket, FsService ftpServerService) {
+    // Avoid forever but allow Exceptions, especially with TLS, as Exceptions != should exit.
+    private final int LOOP_EXCEPTION_CONTROL_MAX = 50;
+    private int loopExControlPlain = 0;
+    private int loopExControlTLS = 0;
+
+    private final Logging logging = new Logging();
+
+    public TcpListener(ServerSocket listenSocket, FsService ftpServerService, SSLServerSocket sslServerSocket) {
+        this.listenSSLSocket = sslServerSocket;
         this.listenSocket = listenSocket;
         this.ftpServerService = ftpServerService;
     }
@@ -47,30 +64,147 @@ public class TcpListener extends Thread {
 
     @Override
     public void run() {
-        try {
-            Socket clientSocket;
+        listenPlainSocket();
+        listenSSLSocket();
+    }
+
+    private void listenPlainSocket() {
+        if (listenSocket == null) return;
+        if (FsSettings.isImplicitOnly()) return;
+
+        new Thread(() -> {
+            try {
+                Socket clientSocket;
+                while (true) {
+                    try {
+                        clientSocket = listenSocket.accept(); // blocks loop until next connection
+                        logging.appendLog("Plain/Explicit port connected...");
+                    } catch (Exception e) {
+                        loopExControlPlain++;
+                        // call to close() on server off causes SocketException here with "Socket closed"
+                        final String msg = e.getMessage();
+                        if (msg != null && msg.contains("Socket closed")) {
+                            if (ftpServerService.isConnWakelockRunning()) {
+                                ftpServerService.releaseWakelocks();
+                            }
+                            return;
+                        }
+                        // Simple retry and fail back to next catch or continue on success
+                        clientSocket = listenSocket.accept();
+                    }
+
+                    if (IPSecurity.isIPValid(clientSocket.getInetAddress().toString())) {
+                        spawnSession(clientSocket, null);
+                        loopExControlPlain = 0;
+                    } else {
+                        Log.d(TAG, "IP denied access.");
+                        logging.appendLog("IP denied access.");
+                        clientSocket.close();
+                    }
+
+                    if (loopExControlPlain > LOOP_EXCEPTION_CONTROL_MAX) {
+                        loopExControlPlain = 0;
+                        if (ftpServerService.isConnWakelockRunning()) {
+                            ftpServerService.releaseWakelocks();
+                        }
+                        break;
+                    }
+                }
+            } catch (Exception e) {
+                loopExControlPlain++;
+                Log.d(TAG, "Exception in TcpListener");
+                if (ftpServerService.isConnWakelockRunning()) {
+                    ftpServerService.releaseWakelocks();
+                }
+            }
+        }).start();
+    }
+
+    private void listenSSLSocket() {
+        if (listenSocket == null) return;
+        if (!FsSettings.isImplicitUsed()) return;
+
+        new Thread(() -> {
+            SSLSocket clientSSLSocket;
+            //  might want anyway to eliminate a port from listening.
             while (true) {
                 try {
-                    clientSocket = listenSocket.accept(); // blocks loop until next connection
-                } catch (Exception e) {
-                    // call to close() on server off causes SocketException here with "Socket closed"
-                    final String msg = e.getMessage();
-                    if (msg != null && msg.contains("Socket closed")) {
-                        if (ftpServerService.isConnWakelockRunning()) ftpServerService.releaseWakelocks();
-                        return;
+                    try {
+                        clientSSLSocket = (SSLSocket) listenSSLSocket.accept();
+                        logging.appendLog("FTPS implicit port connected");
+                    } catch (Exception e) {
+                        loopExControlTLS++;
+                        // call to close() on server off causes SocketException here with "Socket closed"
+                        final String msg = e.getMessage();
+                        if (msg != null && msg.contains("Socket closed")) {
+                            if (ftpServerService.isConnWakelockRunning()) {
+                                ftpServerService.releaseWakelocks();
+                            }
+                            return;
+                        }
+                        // Simple retry and fail back to next catch or continue on success
+                        clientSSLSocket = (SSLSocket) listenSSLSocket.accept();
                     }
-                    // Simple retry and fail back to next catch or continue on success
-                    clientSocket = listenSocket.accept();
+
+                    if (IPSecurity.isIPValid(clientSSLSocket.getInetAddress().toString())) {
+                        Log.i(TAG, "New connection, spawned thread");
+                        final SSLSocket finalClientSSLSocket = clientSSLSocket;
+                        clientSSLSocket.addHandshakeCompletedListener(event -> {
+                            Log.i(TAG, "Handshake completed");
+                            logging.appendLog("Handshake completed");
+                            changeSocketTimeout(finalClientSSLSocket, 0);
+                            spawnSession(null, finalClientSSLSocket);
+                            loopExControlTLS = 0;
+                        });
+                        Log.i(TAG, "Begin FTPS handshake");
+                        logging.appendLog("Begin FTPS handshake");
+                        // Incorrect setup will cause startHandshake() to timeout
+                        clientSSLSocket.setTcpNoDelay(true);
+                        changeSocketTimeout(clientSSLSocket, 30000);
+                        clientSSLSocket.startHandshake();
+                    } else {
+                        Log.d(TAG, "IP denied access.");
+                        logging.appendLog("IP denied access.");
+                        clientSSLSocket.close();
+                    }
+
+                } catch (Exception e) {
+                    loopExControlTLS++;
+                    // Samsung Files implicit reaches here from it not liking the handshake.
+                    // Certs can cause handshake failures and end up here.
+                    // Handshake timeout will end up here.
+                    // Clients can fail the handshake.
+                    Log.d(TAG, "Exception in TcpListener");
+                    if (ftpServerService.isConnWakelockRunning()) {
+                        ftpServerService.releaseWakelocks();
+                    }
                 }
-                Log.i(TAG, "New connection, spawned thread");
-                ftpServerService.createConnWakeLock();
-                SessionThread newSession = new SessionThread(clientSocket, new LocalDataSocket());
-                newSession.start();
-                ftpServerService.registerSessionThread(newSession);
+                if (loopExControlTLS > LOOP_EXCEPTION_CONTROL_MAX) {
+                    loopExControlTLS = 0;
+                    if (ftpServerService.isConnWakelockRunning()) {
+                        ftpServerService.releaseWakelocks();
+                    }
+                    break;
+                }
             }
-        } catch (Exception e) {
-            Log.d(TAG, "Exception in TcpListener");
-            if (ftpServerService.isConnWakelockRunning()) ftpServerService.releaseWakelocks();
+        }).start();
+    }
+
+    private void changeSocketTimeout(SSLSocket socket, int time) {
+        // Timeout is useful for handshake failures.
+        // Timeout must be 0 on handshake completion(!) or else randomly quits with enough work.
+        try {
+            socket.setSoTimeout(time);
+        } catch (SocketException e) {
+            throw new RuntimeException(e);
         }
+    }
+
+    private void spawnSession(Socket clientSocket, SSLSocket sslClientSocket) {
+        Log.i(TAG, "New connection, spawned thread");
+        ftpServerService.createConnWakeLock();
+        SessionThread newSession = new SessionThread(clientSocket, new LocalDataSocket(), sslClientSocket);
+        newSession.start();
+        ftpServerService.registerSessionThread(newSession);
     }
 }

--- a/app/src/main/java/be/ppareit/swiftp/utils/FTPSSockets.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/FTPSSockets.java
@@ -1,0 +1,445 @@
+package be.ppareit.swiftp.utils;
+
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Log;
+
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.util.Set;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLServerSocket;
+import javax.net.ssl.SSLServerSocketFactory;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import be.ppareit.swiftp.App;
+import be.ppareit.swiftp.FsSettings;
+import be.ppareit.swiftp.server.LocalDataSocket;
+
+public class FTPSSockets {
+
+    private static final String TAG = FTPSSockets.class.getSimpleName();
+    private final Logging logging = new Logging();
+
+    private static final String KEYSTORE_CERT_FILENAME = "storej.jks";
+    private static final String TRUST_STORE_CERT_FILENAME = "storeb.bks";
+
+    // Need to have static to deal with TLS resumption and consume less time for performance increase.
+    // Allows it to maintain the assigned values on new FTPSSockets() use.
+    // Use synchronized when working with to maintain thread safety.
+    private static SSLServerSocketFactory serverSocketFactory = null;
+    private static SSLSocketFactory socketFactory = null;
+    private static SSLContext context = null;
+
+    public FTPSSockets() {
+    }
+
+    /*
+     * Gets the server socket factory from the static holder.
+     * */
+    public static synchronized SSLServerSocketFactory getServerSocketFactory() {
+        return serverSocketFactory;
+    }
+
+    /*
+     * Gets the socket factory from the static holder.
+     * */
+    public static synchronized SSLSocketFactory getSocketFactory() {
+        return socketFactory;
+    }
+
+    /*
+     * Puts the socket factory to static holder.
+     * */
+    public static synchronized void putSocketFactory(SSLSocketFactory factory) {
+        socketFactory = factory;
+    }
+
+    /*
+     * Puts the server socket factory to static holder.
+     * */
+    public static synchronized void putServerSocketFactory(SSLServerSocketFactory factory) {
+        serverSocketFactory = factory;
+    }
+
+    /*
+     * Gets the static context.
+     * */
+    public static synchronized SSLContext getContext() {
+        return context;
+    }
+
+    /*
+     * Puts the context to static holder.
+     * */
+    public static synchronized void putContext(SSLContext context) {
+        FTPSSockets.context = context;
+    }
+
+    /*
+     * Obtains a new server socket as needed.
+     * */
+    public SSLServerSocket initServerSocket() throws IOException {
+        setContext();
+        setServerSocketFactory();
+        putSocketFactory(null); // Set null to not block on certificate changes.
+        return createServerSocket();
+    }
+
+    /*
+     * Sets up the context.
+     * */
+    private void setContext() {
+        try {
+            KeyManagerFactory kmFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            KeyStore ks = getKeyStore(KEYSTORE_CERT_FILENAME);
+            if (ks == null) return;
+            kmFactory.init(ks, getCertPass());
+            TrustManager[] tm = getTrustManager();
+            if (tm == null) return;
+            putContext(SSLContext.getInstance("TLS"));
+            getContext().init(kmFactory.getKeyManagers(), tm, new SecureRandom());
+        } catch (Exception e) {
+            //
+        }
+    }
+
+    /*
+     * Gets the factory from the content.
+     * */
+    private void setServerSocketFactory() {
+        putServerSocketFactory(getContext().getServerSocketFactory());
+    }
+
+    /*
+     * Re-obtains a factory as needed.
+     * */
+    private SSLSocketFactory getNewSocketFactory(String type) throws KeyStoreException,
+            NoSuchAlgorithmException, UnrecoverableKeyException, KeyManagementException {
+        KeyManagerFactory kmFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        // Need to try to maintain resumption with data sockets in conflict with implicit
+        if (getContext() != null) return getContext().getSocketFactory();
+        // When implicit port is disabled, create it here.
+        kmFactory.init(getKeyStore(KEYSTORE_CERT_FILENAME), getCertPass());
+        SSLContext context = SSLContext.getInstance(type);
+        context.init(kmFactory.getKeyManagers(), getTrustManager(), new SecureRandom());
+        putContext(context);
+        putServerSocketFactory(context.getServerSocketFactory());
+        return context.getSocketFactory();
+    }
+
+    public static char[] getCertPass() {
+        try {
+            MasterKey masterKey = new MasterKey.Builder(App.getAppContext())
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build();
+
+            SharedPreferences encryptedSharedPreferences = EncryptedSharedPreferences.create(
+                    App.getAppContext(),
+                    "encrypted_prefs",
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            );
+
+            return encryptedSharedPreferences.getString("certPass", "").toCharArray();
+
+        } catch (GeneralSecurityException | IOException e) {
+            //
+        }
+        return new char[0];
+    }
+
+    /*
+     * Saves the certificate password internally.
+     * */
+    public static void putCertPass(String s) {
+        try {
+            MasterKey masterKey = new MasterKey.Builder(App.getAppContext())
+                    .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                    .build();
+
+            SharedPreferences encryptedSharedPreferences = null;
+            encryptedSharedPreferences = EncryptedSharedPreferences.create(
+                    App.getAppContext(),
+                    "encrypted_prefs",
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            );
+
+            SharedPreferences.Editor editor = encryptedSharedPreferences.edit();
+
+            editor.putString("certPass", s).apply();
+
+        } catch (GeneralSecurityException | IOException e) {
+            //
+        }
+    }
+
+    /*
+     * Keystore required here for implicit connection use
+     * Load the keystore cert .jks file using getInstance() of BKS as JKS isn't supported.
+     * */
+    private static KeyStore getKeyStore(String filename) {
+        try {
+            String s = KeyStore.getDefaultType(); // Will be BKS (Bouncy Castle)
+            KeyStore keyStore = KeyStore.getInstance(s);
+            //KeyStore keyStore = KeyStore.getInstance("PKCS12"); // Also works here using p12 file
+            FileInputStream fis = getCertInputStream(filename);
+            if (fis == null) return null;
+            keyStore.load(fis, getCertPass());
+            fis.close();
+            return keyStore;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /*
+     * Reads the internal certificate file.
+     * */
+    private static FileInputStream getCertInputStream(String filename) {
+        try {
+            File cacheFile = new File(App.getAppContext().getCacheDir(), filename);
+            long fileSize = cacheFile.length();
+            if (fileSize == 0) return null;
+            return new FileInputStream(cacheFile);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /*
+     * Load the trust store cert .bks file using getInstance() of BKS.
+     * */
+    private static TrustManager[] getTrustManager() {
+        try {
+            String s = TrustManagerFactory.getDefaultAlgorithm();
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(s);
+            trustManagerFactory.init(getKeyStore(TRUST_STORE_CERT_FILENAME));
+            return trustManagerFactory.getTrustManagers();
+        } catch (Exception e) {
+            return null; // Can be null (not absolutely required). Will use default trust instead.
+        }
+    }
+
+    /*
+     * Checks the internal keystore file to see if its working.
+     * Will return false if the cert is broken, no password, or wrong password.
+     * */
+    public static boolean checkKeyStore() {
+        return getKeyStore(KEYSTORE_CERT_FILENAME) != null;
+    }
+
+    /*
+     * Checks the internal trust store file to see if its working.
+     * Will return false if the cert is broken, no password, or wrong password.
+     * */
+    public static boolean checkTrustStore() {
+        return getKeyStore(TRUST_STORE_CERT_FILENAME) != null;
+    }
+
+    /*
+     * Deletes the internal keystore file.
+     * */
+    public static void deleteKeyStore() {
+        File cacheFile = new File(App.getAppContext().getCacheDir(), KEYSTORE_CERT_FILENAME);
+        cacheFile.delete();
+    }
+
+    /*
+     * Deletes the internal trust store file.
+     * */
+    public static void deleteTrustStore() {
+        File cacheFile = new File(App.getAppContext().getCacheDir(), TRUST_STORE_CERT_FILENAME);
+        cacheFile.delete();
+    }
+
+    /*
+     * Creates the implicit socket.
+     * */
+    private SSLServerSocket createServerSocket() throws IOException {
+        SSLServerSocket sslServerSocket = (SSLServerSocket) getServerSocketFactory()
+                .createServerSocket(FsSettings.getImplicitPort());
+        sslServerSocket.setReuseAddress(false);
+        sslServerSocket.setReceiveBufferSize(4);
+        sslServerSocket.setEnableSessionCreation(true); // true is default; false breaks things
+        sslServerSocket.setEnabledProtocols(getChosenProtocols(sslServerSocket.getSupportedProtocols()));
+        sslServerSocket.setEnabledCipherSuites(sslServerSocket.getSupportedCipherSuites());
+        //sslServerSocket.setNeedClientAuth(true); // officially buggy; doesn't work (use SSLParameters)
+        //sslServerSocket.setWantClientAuth(false); // officially buggy; doesn't work (use SSLParameters)
+        if (Build.VERSION.SDK_INT >= 24) sslServerSocket.setSSLParameters(getClientCertParams());
+        sslServerSocket.setUseClientMode(false); // Of no use here; true only breaks things
+        return sslServerSocket;
+    }
+
+    /*
+     * Creates the socket for AUTH.
+     * */
+    public SSLSocket createAuthSocket(String type, Socket socket) {
+        SSLSocket sslSocket;
+        try {
+            if (getSocketFactory() == null) putSocketFactory(getNewSocketFactory(type));
+            sslSocket = (SSLSocket) getSocketFactory().createSocket(socket, null, socket.getPort(), false);
+            sslSocket.setReuseAddress(true);
+            sslSocket.setEnabledProtocols(getChosenProtocols(sslSocket.getSupportedProtocols()));
+            sslSocket.setEnabledCipherSuites(sslSocket.getSupportedCipherSuites());
+            if (Build.VERSION.SDK_INT >= 24) sslSocket.setSSLParameters(getClientCertParams());
+            sslSocket.setUseClientMode(false);
+            //sslSocket.setReceiveBufferSize();
+            sslSocket.setSoTimeout(30000);
+            sslSocket.addHandshakeCompletedListener(event -> {
+                Log.i(TAG, "FTPS handshake completed");
+                logging.appendLog("Handshake completed");
+                try {
+                    event.getSocket().setSoTimeout(0);
+                } catch (Exception e) {
+                    //
+                }
+            });
+            Log.i(TAG, "Begin FTPS handshake");
+            logging.appendLog("Begin FTPS handshake");
+            sslSocket.startHandshake();
+        } catch (Exception e) {
+            Log.e(TAG, type + " failed: " + e.getLocalizedMessage());
+            sslSocket = null;
+        }
+        return sslSocket;
+    }
+
+    public SSLServerSocket createSSLServerSocketEpsv(InetAddress address) throws IOException {
+        SSLServerSocket sslServerSocket;
+        sslServerSocket = (SSLServerSocket) FTPSSockets.getServerSocketFactory().createServerSocket(
+                LocalDataSocket.getNewPort(),
+                LocalDataSocket.TCP_CONNECTION_BACKLOG,
+                address
+        );
+        sslServerSocket.setReuseAddress(true);
+        sslServerSocket.setEnabledProtocols(getChosenProtocols(sslServerSocket.getSupportedProtocols()));
+        sslServerSocket.setEnabledCipherSuites(sslServerSocket.getSupportedCipherSuites()); //ignored Android 10+
+        if (Build.VERSION.SDK_INT >= 24) sslServerSocket.setSSLParameters(getClientCertParams());
+        sslServerSocket.setUseClientMode(false);
+        sslServerSocket.setEnableSessionCreation(true);
+        return sslServerSocket;
+    }
+
+    public SSLServerSocket createSSLServerSocket() throws IOException {
+        SSLServerSocket sslServerSocket;
+        //SSLSocketFactory factory = SSLContext.getDefault().getSocketFactory();
+        sslServerSocket = (SSLServerSocket) FTPSSockets.getServerSocketFactory().createServerSocket(
+                LocalDataSocket.getNewPort(),
+                LocalDataSocket.TCP_CONNECTION_BACKLOG
+        );
+        sslServerSocket.setReuseAddress(true);
+        sslServerSocket.setEnabledProtocols(getChosenProtocols(sslServerSocket.getSupportedProtocols()));
+        sslServerSocket.setEnabledCipherSuites(sslServerSocket.getSupportedCipherSuites()); //ignored Android 10+
+        if (Build.VERSION.SDK_INT >= 24) sslServerSocket.setSSLParameters(getClientCertParams());
+        sslServerSocket.setUseClientMode(false); // Clients don't like true here; true only breaks things
+        sslServerSocket.setEnableSessionCreation(true); // true is default; false breaks things
+        return sslServerSocket;
+    }
+
+    public SSLSocket createSSLSocket(InetAddress remoteAddress, int remotePort) throws IOException {
+        Socket plainSocket = new Socket(remoteAddress, remotePort);
+        //SSLSocketFactory factory = SSLContext.getDefault().getSocketFactory();
+        SSLSocketFactory factory = FTPSSockets.getSocketFactory();
+        SSLSocket sslSocket = (SSLSocket) factory.createSocket(plainSocket,
+                remoteAddress.getHostAddress(),
+                remotePort,
+                false
+        );
+        sslSocket.setReuseAddress(true);
+        sslSocket.setEnabledProtocols(getChosenProtocols(sslSocket.getSupportedProtocols()));
+        sslSocket.setEnabledCipherSuites(sslSocket.getSupportedCipherSuites()); //ignored Android 10+
+        if (Build.VERSION.SDK_INT >= 24) sslSocket.setSSLParameters(getClientCertParams());
+        sslSocket.setUseClientMode(false);
+        sslSocket.setEnableSessionCreation(true);
+        return sslSocket;
+    }
+
+    public SSLSocket createSSLSocket6(Inet6Address remote6Address, int remote6Port) throws IOException {
+        Socket plainSocket = new Socket(remote6Address, remote6Port);
+        //SSLSocketFactory factory = SSLContext.getDefault().getSocketFactory();
+        SSLSocketFactory factory = FTPSSockets.getSocketFactory();
+        SSLSocket sslSocket = (SSLSocket) factory.createSocket(
+                plainSocket,
+                remote6Address.getHostAddress(),
+                remote6Port,
+                false
+        );
+        sslSocket.setReuseAddress(true);
+        sslSocket.setEnabledProtocols(getChosenProtocols(sslSocket.getSupportedProtocols()));
+        sslSocket.setEnabledCipherSuites(sslSocket.getSupportedCipherSuites()); //ignored Android 10+
+        if (Build.VERSION.SDK_INT >= 24) sslSocket.setSSLParameters(getClientCertParams());
+        sslSocket.setUseClientMode(false);
+        sslSocket.setEnableSessionCreation(true);
+        return sslSocket;
+    }
+
+    /*
+     * Enables use of requiring client certificate for connecting. This is used to improve security.
+     * When used, all clients without the pkcs12 cert in use will be denied.
+     * */
+    private SSLParameters getClientCertParams() {
+        SSLParameters params = new SSLParameters();
+        // Java is broken with the direct socket setting of this so bye bye Android 6.
+        if (FsSettings.useClientCert()) {
+            params.setNeedClientAuth(true);
+            return params;
+        }
+        return params;
+    }
+
+    /*
+    * Gets the protocols as chosen by the user or returns the default list if nothing has been chosen.
+    * This is used to improve connection security. If for example, TLSv1.1 is not in the list, then
+    * a client cannot try to partially downgrade to TLSv1.1 as it will be denied.
+    * */
+    private String[] getChosenProtocols(String[] socketProtocols) {
+        String[] s = socketProtocols;
+        final Set<String> list = FsSettings.getAllowedProtocols();
+        if (!list.isEmpty()) {
+            s = new String[list.size()];
+            list.toArray(s);
+        }
+        return s;
+    }
+
+    /*
+    * Returns a dynamic list of supported protocols for the socket/device.
+    * Examples:
+    * Android 8: TLSv1, TLSv1.1, TLSv1.2
+    * Android 14: TLSv1, TLSv1.1, TLSv1.2, TLSv1.3
+    * */
+    public static CharSequence[] getSupportedProtocols() {
+        try {
+            SSLServerSocket socket = (SSLServerSocket) SSLServerSocketFactory.getDefault().createServerSocket();
+            CharSequence[] list = socket.getSupportedProtocols();
+            socket.close();
+            return list;
+        } catch (Exception e) {
+            return new CharSequence[0];
+        }
+    }
+}

--- a/app/src/main/java/be/ppareit/swiftp/utils/IPSecurity.java
+++ b/app/src/main/java/be/ppareit/swiftp/utils/IPSecurity.java
@@ -1,0 +1,132 @@
+package be.ppareit.swiftp.utils;
+
+import android.util.ArraySet;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import be.ppareit.swiftp.FsSettings;
+
+public class IPSecurity {
+
+    private static final boolean IS_VALID = true;
+    private static final boolean IS_INVALID = false;
+    private static final int VALID = 0;
+    private static final int INVALID = 1;
+
+    private static final ConcurrentHashMap<String, Integer> ipFailCount = new ConcurrentHashMap<>();
+
+    private static Set<String> ipList;
+    private static Set<String> allowList;
+    private static Set<String> failList;
+
+    static Logging logging = new Logging();
+
+    public IPSecurity() {
+    }
+
+    public static void putIPFail(String ip) {
+        Integer count = 1;
+        if (ipFailCount.containsKey(ip)) {
+            count = ipFailCount.get(ip);
+            if (count == null) count = 1;
+            else count++;
+        }
+        ipFailCount.put(ip, count);
+    }
+
+    public static Integer getIPFail(String ip) {
+        if (ipFailCount.get(ip) != null) return ipFailCount.get(ip);
+        return 0;
+    }
+
+    public static boolean isIPValid(String ip) {
+
+        // IP enhancement settings
+        final boolean isDenyUntilAllowed = FsSettings.isDenyUntilAllowed();
+        final boolean isDenyOnFailedLogins = FsSettings.isDenyOnFailedLogins();
+
+        if (!isDenyUntilAllowed
+                && !isDenyOnFailedLogins) {
+            // IP security enhancement settings are all disabled.
+            logging.appendLog("IP connected" + ip);
+            return true;
+        }
+
+        // Bring up IP lists
+        ipList = FsSettings.getIPList();
+        allowList = FsSettings.getAllowList();
+        failList = FsSettings.getFailList();
+
+        logIP(ip);
+
+        int result = shouldDenyUntilAllowed(isDenyUntilAllowed, ip);
+        if (result == INVALID) return IS_INVALID;
+        if (result == VALID) return IS_VALID;
+
+        result = shouldDenyOnFailedLogin(isDenyOnFailedLogins, ip);
+        if (result == INVALID) return IS_INVALID;
+        if (result == VALID) return IS_VALID;
+
+        return IS_INVALID;
+    }
+
+    private static void logIP(String ip) {
+        if (!ipList.contains(ip)) {
+            logging.appendLog("New IP connected" + ip);
+            Set<String> newList = new ArraySet<>();
+            newList.add(ip);
+            newList.addAll(ipList);
+            FsSettings.putIPList(newList);
+        } else {
+            logging.appendLog("Existing IP connected" + ip);
+        }
+    }
+
+    private static int shouldDenyUntilAllowed(boolean isDenyUntilAllowed, String ip) {
+        if (isDenyUntilAllowed) {
+            if (allowList.contains(ip)) {
+                return VALID;
+            } else {
+                // deal with * use eg 000.111.* (helpful for mobile connections)
+                for (String s : allowList) {
+                    if (s.contains("*")) {
+                        String aIP = "";
+                        if (!s.startsWith("*"))
+                            aIP = s.substring(0, s.indexOf("*") - 1);
+                        // else... not allowing * at start.
+                        if (!aIP.isEmpty()) { // not allowing empty
+                            if (ip.startsWith(aIP)) {
+                                return VALID;
+                            }
+                        }
+                    }
+                }
+                logging.appendLog("IP denied entry " + ip);
+                return INVALID;
+            }
+        }
+        return -1;
+    }
+
+    private static int shouldDenyOnFailedLogin(boolean isDenyOnFailedLogins, String ip) {
+        if (isDenyOnFailedLogins) {
+            int count = 0;
+            if (failList.contains(ip)) count = 3;
+            count += getIPFail(ip);
+            if (count <= 3 || allowList.contains(ip)) {
+                return VALID;
+            } else {
+                if (!failList.contains(ip)) {
+                    Set<String> newList = new ArraySet<>();
+                    newList.add(ip);
+                    newList.addAll(failList);
+                    FsSettings.putFailList(newList);
+                }
+                logging.appendLog("IP denied. Too many failures." + ip);
+                return INVALID;
+            }
+        }
+        return -1;
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,7 +90,6 @@ Gemeldete Probleme und Verbesserungsvorschläge sind unter https://github.com/pp
     <string name="app_theme">Thema...</string>
 
     <string name="battery_saver_setting_title">Batteriesparmodus</string>
-    <string name="battery_saver_desc">HINWEIS: Sie *müssen* den Server nach der Änderung manuell neu starten.</string>
     <string name="bs_high">HOCH</string>
     <string name="bs_low">NIEDRIG</string>
     <string name="bs_deep">TIEF</string>
@@ -100,4 +99,37 @@ Gemeldete Probleme und Verbesserungsvorschläge sind unter https://github.com/pp
 
     <string name="anon_max_conn">Max. gleichzeitige Verbindungen</string>
     <string name="manage_anon_label">Anonym verwalten…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Ports…</string>
+    <string name="general_title">Allgemein…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Sicherheitsverbesserungen…</string>
+    <string name="port_number_label_data_low">Datenportnummernbereich niedrig</string>
+    <string name="port_number_label_data_high">Datenportnummernbereich hoch</string>
+    <string name="port_number_label_implicit">Implizite FTP-Portnummer</string>
+    <string name="enable_tls">TLS aktivieren</string>
+    <string name="enable_tls_implicit">Implizit aktivieren</string>
+    <string name="enable_ssl">SSL aktivieren</string>
+    <string name="disable_plain_port">Nur implizit verwenden</string>
+    <string name="disable_plain_not_explicit">Nur implizit und explizit verwenden</string>
+    <string name="cert_keystore">Zertifikat: Keystore importieren (jks)</string>
+    <string name="cert_trust_store">Zertifikat: Trust Store importieren (bks)</string>
+    <string name="cert_pass">Zertifikat: Passwort</string>
+    <string name="cert_show_pass">Zertifikat: Passwort anzeigen</string>
+    <string name="cert_use_client">Client-Zertifikat erforderlich</string>
+    <string name="early_150_response">Workaround für frühe 150-Antwort</string>
+    <string name="ip_list_title">IPs zulassen/verweigern</string>
+    <string name="deny_until_allowed">Verweigern bis erlaubt</string>
+    <string name="manually_add_ip">IP manuell hinzufügen</string>
+    <string name="deny_on_failed_logins">Verweigern bei 3 fehlgeschlagenen Anmeldungen</string>
+    <string name="clear_unused_ips">Nicht verwendete IPs löschen</string>
+    <string name="implicit_only_summary">Deaktiviert einfachen Port</string>
+    <string name="implicit_explicit_only_summary">Aktiviert nur Verschlüsselung</string>
+    <string name="disable_banner_title">Banner deaktivieren</string>
+    <string name="disable_feat_title">FEAT deaktivieren</string>
+    <string name="disable_syst_title">SYST deaktivieren</string>
+    <string name="tls_limit_protocols_title">Protokolle begrenzen</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -144,7 +144,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="mixed_theme">Ανάμεικτο Θέμα</string>
 
     <string name="battery_saver_setting_title">Εξοικονόμηση μπαταρίας</string>
-    <string name="battery_saver_desc">ΣΗΜΕΙΩΣΗ: *Πρέπει* να κάνετε μη αυτόματη επανεκκίνηση του διακομιστή μετά την αλλαγή.</string>
     <string name="bs_high">ΥΨΗΛΟΣ</string>
     <string name="bs_low">ΧΑΜΗΛΟΣ</string>
     <string name="bs_deep">ΒΑΘΥΣ</string>
@@ -154,5 +153,38 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Μέγιστες ταυτόχρονες συνδέσεις</string>
     <string name="manage_anon_label">Διαχείριση ανώνυμων…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Λιμάνια…</string>
+    <string name="general_title">Γενικός…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Βελτιώσεις ασφαλείας…</string>
+    <string name="port_number_label_data_low">Χαμηλό εύρος αριθμού θύρας δεδομένων</string>
+    <string name="port_number_label_data_high">Υψηλό εύρος αριθμού θύρας δεδομένων</string>
+    <string name="port_number_label_implicit">Αριθμός σιωπηρής θύρας FTPS</string>
+    <string name="enable_tls">Ενεργοποίηση TLS</string>
+    <string name="enable_tls_implicit">Ενεργοποίηση σιωπηρής</string>
+    <string name="enable_ssl">Ενεργοποίηση SSL</string>
+    <string name="disable_plain_port">Χρησιμοποιήστε μόνο σιωπηρά</string>
+    <string name="disable_plain_not_explicit">Χρησιμοποιήστε μόνο έμμεσα και ρητά</string>
+    <string name="cert_keystore">Πιστοποιητικό: import keystore (jks)</string>
+    <string name="cert_trust_store">Πιστοποιητικό: import trust store (bks)</string>
+    <string name="cert_pass">Πιστοποιητικό: κωδικός πρόσβασης</string>
+    <string name="cert_show_pass">Πιστοποιητικό: εμφάνιση κωδικού πρόσβασης</string>
+    <string name="cert_use_client">Απαιτείται πιστοποιητικό πελάτη</string>
+    <string name="early_150_response">Πρόωρη λύση απόκρισης 150</string>
+    <string name="ip_list_title">Αποδοχή/απόρριψη IP</string>
+    <string name="deny_until_allowed">Άρνηση μέχρι να επιτραπεί</string>
+    <string name="manually_add_ip">Μη αυτόματη προσθήκη IP</string>
+    <string name="deny_on_failed_logins">Άρνηση σε 3 αποτυχημένες συνδέσεις</string>
+    <string name="clear_unused_ips">Διαγράψτε τις αχρησιμοποίητες IP</string>
+    <string name="implicit_only_summary">Απενεργοποιεί την απλή θύρα</string>
+    <string name="implicit_explicit_only_summary">Ενεργοποιεί μόνο την κρυπτογράφηση</string>
+    <string name="disable_banner_title">Απενεργοποίηση banner</string>
+    <string name="disable_feat_title">Απενεργοποιήστε το FEAT</string>
+    <string name="disable_syst_title">Απενεργοποιήστε το SYST</string>
+    <string name="tls_limit_protocols_title">Περιορίστε τα πρωτόκολλα</string>
 </resources>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -167,7 +167,6 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
     <string name="write_external_storage_old_android_version_summary">En estos dispositivos, toda lo guardado está disponible utilizando la jerarquía de archivos.</string>
 
     <string name="battery_saver_setting_title">Ahorro de batería</string>
-    <string name="battery_saver_desc">NOTA: *Debe* reiniciar manualmente el servidor después de realizar el cambio.</string>
     <string name="bs_high">ALTO</string>
     <string name="bs_low">BAJO</string>
     <string name="bs_deep">PROFUNDO</string>
@@ -177,5 +176,38 @@ implementarán, mira el registro de incidencias en https://github.com/ppareit/sw
 
     <string name="anon_max_conn">Conexiones simultáneas máximas</string>
     <string name="manage_anon_label">Administrar anónimo…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Puertos…</string>
+    <string name="general_title">General…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Mejoras de seguridad…</string>
+    <string name="port_number_label_data_low">Rango de número de puerto de datos bajo</string>
+    <string name="port_number_label_data_high">Rango de número de puerto de datos alto</string>
+    <string name="port_number_label_implicit">Número de puerto implícito FTPS</string>
+    <string name="enable_tls">Habilitar TLS</string>
+    <string name="enable_tls_implicit">Habilitar implícito</string>
+    <string name="enable_ssl">Habilitar SSL</string>
+    <string name="disable_plain_port">Usar solo implícito</string>
+    <string name="disable_plain_not_explicit">Utilice sólo implícito y explícito</string>
+    <string name="cert_keystore">Certificado: importar almacén de claves (jks)</string>
+    <string name="cert_trust_store">Certificado: importar almacén de confianza (bks)</string>
+    <string name="cert_pass">Certificado: contraseña</string>
+    <string name="cert_show_pass">Certificado: mostrar contraseña</string>
+    <string name="cert_use_client">Requerir certificado de cliente</string>
+    <string name="early_150_response">Solución alternativa de respuesta temprana 150</string>
+    <string name="ip_list_title">Permitir/denegar IP</string>
+    <string name="deny_until_allowed">Negar hasta que se permita</string>
+    <string name="manually_add_ip">Agregar IP manualmente</string>
+    <string name="deny_on_failed_logins">Denegar en 3 inicios de sesión fallidos</string>
+    <string name="clear_unused_ips">Borrar IP no utilizadas</string>
+    <string name="implicit_only_summary">Deshabilita el puerto simple</string>
+    <string name="implicit_explicit_only_summary">Solo habilita el cifrado</string>
+    <string name="disable_banner_title">Desactivar banner</string>
+    <string name="disable_feat_title">Deshabilitar FUNCIÓN</string>
+    <string name="disable_syst_title">Deshabilitar SISTEMA</string>
+    <string name="tls_limit_protocols_title">Limitar protocolos</string>
 </resources>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -149,7 +149,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="app_theme">Thème...</string>
 
     <string name="battery_saver_setting_title">Économiseur de batterie</string>
-    <string name="battery_saver_desc">REMARQUE : Vous *devez* redémarrer manuellement le serveur après la modification.</string>
     <string name="bs_high">HAUT</string>
     <string name="bs_low">FAIBLE</string>
     <string name="bs_deep">PROFOND</string>
@@ -159,4 +158,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Nombre maximum de connexions simultanées</string>
     <string name="manage_anon_label">Gérer les anonymes…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Port…</string>
+    <string name="general_title">Général…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Améliorations de la sécurité…</string>
+    <string name="port_number_label_data_low">Plage de numéros de port de données faible</string>
+    <string name="port_number_label_data_high">Plage de numéros de port de données élevée</string>
+    <string name="port_number_label_implicit">Numéro de port implicite FTPS</string>
+    <string name="enable_tls">Activer TLS</string>
+    <string name="enable_tls_implicit">Activer l\'implicite</string>
+    <string name="enable_ssl">Activer SSL</string>
+    <string name="disable_plain_port">Utiliser implicitement uniquement</string>
+    <string name="disable_plain_not_explicit">Utiliser uniquement implicite et explicite</string>
+    <string name="cert_keystore">Certificat : importer un magasin de clés (jks)</string>
+    <string name="cert_trust_store">Certificat : importer un magasin de confiance (bks)</string>
+    <string name="cert_pass">Certificat : mot de passe</string>
+    <string name="cert_show_pass">Certificat : afficher le mot de passe</string>
+    <string name="cert_use_client">Exiger un certificat client</string>
+    <string name="early_150_response">Solution de contournement de réponse précoce 150</string>
+    <string name="ip_list_title">Autoriser/refuser les IP</string>
+    <string name="deny_until_allowed">Refuser jusqu\'à autorisation</string>
+    <string name="manually_add_ip">Ajouter manuellement une adresse IP</string>
+    <string name="deny_on_failed_logins">Refuser sur 3 échecs de connexion</string>
+    <string name="clear_unused_ips">Effacer les IP inutilisées</string>
+    <string name="implicit_only_summary">Désactive le port simple</string>
+    <string name="implicit_explicit_only_summary">Active le cryptage uniquement</string>
+    <string name="disable_banner_title">Désactiver la bannière</string>
+    <string name="disable_feat_title">Désactiver FEAT</string>
+    <string name="disable_syst_title">Désactiver SYST</string>
+    <string name="tls_limit_protocols_title">Limiter les protocoles</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -94,7 +94,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="app_theme">Tema...</string>
 
     <string name="battery_saver_setting_title">Risparmio batteria</string>
-    <string name="battery_saver_desc">NOTA: *è necessario* riavviare manualmente il server dopo la modifica.</string>
     <string name="bs_high">ALTO</string>
     <string name="bs_low">BASSO</string>
     <string name="bs_deep">PROFONDO</string>
@@ -104,4 +103,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Numero massimo di connessioni simultanee</string>
     <string name="manage_anon_label">Gestisci anonimo…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Porti…</string>
+    <string name="general_title">Generale…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Miglioramenti della sicurezza…</string>
+    <string name="port_number_label_data_low">Intervallo numero porta dati basso</string>
+    <string name="port_number_label_data_high">Intervallo numero porta dati alto</string>
+    <string name="port_number_label_implicit">Numero di porta implicita FTPS</string>
+    <string name="enable_tls">Abilita TLS</string>
+    <string name="enable_tls_implicit">Abilita implicito</string>
+    <string name="enable_ssl">Abilita SSL</string>
+    <string name="disable_plain_port">Utilizzare solo implicito</string>
+    <string name="disable_plain_not_explicit">Utilizzare solo implicito ed esplicito</string>
+    <string name="cert_keystore">Certificato: importa archivio chiavi (jks)</string>
+    <string name="cert_trust_store">Certificato: importa archivio attendibile (bks)</string>
+    <string name="cert_pass">Certificato: password</string>
+    <string name="cert_show_pass">Certificato: mostra la password</string>
+    <string name="cert_use_client">Richiedi certificato client</string>
+    <string name="early_150_response">Soluzione alternativa per la risposta iniziale 150</string>
+    <string name="ip_list_title">Consenti/nega IP</string>
+    <string name="deny_until_allowed">Negare fino al permesso</string>
+    <string name="manually_add_ip">Aggiungi manualmente l\'IP</string>
+    <string name="deny_on_failed_logins">Nega su 3 accessi non riusciti</string>
+    <string name="clear_unused_ips">Cancella gli IP non utilizzati</string>
+    <string name="implicit_only_summary">Disabilita la porta normale</string>
+    <string name="implicit_explicit_only_summary">Abilita solo la crittografia</string>
+    <string name="disable_banner_title">Disabilita banner</string>
+    <string name="disable_feat_title">Disabilita FEAT</string>
+    <string name="disable_syst_title">Disabilita SIST</string>
+    <string name="tls_limit_protocols_title">Limitare i protocolli</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -128,7 +128,6 @@ https://github.com/ppareit/swiftp/issues を参照してください。\n\n
     <string name="app_theme">テーマ...</string>
 
     <string name="battery_saver_setting_title">バッテリーセーバー</string>
-    <string name="battery_saver_desc">注: 変更後はサーバーを手動で再起動する必要があります。</string>
     <string name="bs_high">高い</string>
     <string name="bs_low">低い</string>
     <string name="bs_deep">深い</string>
@@ -138,4 +137,37 @@ https://github.com/ppareit/swiftp/issues を参照してください。\n\n
 
     <string name="anon_max_conn">最大同時接続数</string>
     <string name="manage_anon_label">匿名で管理する…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">ポート…</string>
+    <string name="general_title">全般…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">セキュリティ強化…</string>
+    <string name="port_number_label_data_low">データ ポート番号範囲の下限</string>
+    <string name="port_number_label_data_high">データ ポート番号範囲の上限</string>
+    <string name="port_number_label_implicit">FTPS 暗黙のポート番号</string>
+    <string name="enable_tls">TLS を有効にする</string>
+    <string name="enable_tls_implicit">暗黙を有効にする</string>
+    <string name="enable_ssl">SSL を有効にする</string>
+    <string name="disable_plain_port">暗黙のみを使用する</string>
+    <string name="disable_plain_not_explicit">暗黙と明示のみを使用する</string>
+    <string name="cert_keystore">証明書: キーストア (jks) をインポート</string>
+    <string name="cert_trust_store">証明書: トラスト ストア (bks) をインポート</string>
+    <string name="cert_pass">証明書: パスワード</string>
+    <string name="cert_show_pass">証明書: パスワードを表示</string>
+    <string name="cert_use_client">クライアント証明書が必要</string>
+    <string name="early_150_response">早期 150 応答の回避策</string>
+    <string name="ip_list_title">IP を許可/拒否</string>
+    <string name="deny_until_allowed">許可されるまで拒否</string>
+    <string name="manually_add_ip">IP を手動で追加</string>
+    <string name="deny_on_failed_logins">ログインに 3 回失敗すると拒否</string>
+    <string name="clear_unused_ips">未使用の IP をクリア</string>
+    <string name="implicit_only_summary">プレーン ポートを無効にする</string>
+    <string name="implicit_explicit_only_summary">暗号化のみを有効にする</string>
+    <string name="disable_banner_title">バナーを無効にする</string>
+    <string name="disable_feat_title">FEAT を無効にする</string>
+    <string name="disable_syst_title">SYST を無効にする</string>
+    <string name="tls_limit_protocols_title">プロトコルを制限する</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -96,7 +96,6 @@ van de volgende versie staan op https://github.com/ppareit/swiftp/issues .\n\n
     <string name="app_theme">Thema...</string>
 
     <string name="battery_saver_setting_title">Batterij bespaarder</string>
-    <string name="battery_saver_desc">OPMERKING: U *moet* de server handmatig opnieuw opstarten na het wijzigen.</string>
     <string name="bs_high">HOOG</string>
     <string name="bs_low">LAAG</string>
     <string name="bs_deep">DIEP</string>
@@ -109,4 +108,37 @@ van de volgende versie staan op https://github.com/ppareit/swiftp/issues .\n\n
     <string name="display_logcat">Toon logcat</string>
     <string name="anon_max_conn">Maximaal gelijktijdige verbindingen</string>
     <string name="manage_anon_label">Beheer anoniem…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Poorten…</string>
+    <string name="general_title">Algemeen…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Beveiligingsverbeteringen…</string>
+    <string name="port_number_label_data_low">Datapoortnummerbereik laag</string>
+    <string name="port_number_label_data_high">Datapoortnummerbereik hoog</string>
+    <string name="port_number_label_implicit">FTPS impliciet poortnummer</string>
+    <string name="enable_tls">Schakel TLS in</string>
+    <string name="enable_tls_implicit">Schakel impliciet in</string>
+    <string name="enable_ssl">Schakel SSL in</string>
+    <string name="disable_plain_port">Gebruik alleen impliciet</string>
+    <string name="disable_plain_not_explicit">Gebruik alleen impliciet en expliciet</string>
+    <string name="cert_keystore">Certificaat: sleutelarchief importeren (jks)</string>
+    <string name="cert_trust_store">Certificaat: import trust store (bks)</string>
+    <string name="cert_pass">Certificaat: wachtwoord</string>
+    <string name="cert_show_pass">Certificaat: toon wachtwoord</string>
+    <string name="cert_use_client">Vereist clientcertificaat</string>
+    <string name="early_150_response">Tijdelijke oplossing voor vroege 150-reacties</string>
+    <string name="ip_list_title">IP\'s toestaan/weigeren</string>
+    <string name="deny_until_allowed">Weigeren totdat het is toegestaan</string>
+    <string name="manually_add_ip">Handmatig IP toevoegen</string>
+    <string name="deny_on_failed_logins">Weigeren bij 3 mislukte aanmeldingen</string>
+    <string name="clear_unused_ips">Wis ongebruikte IP\'s</string>
+    <string name="implicit_only_summary">Schakelt gewone poort uit</string>
+    <string name="implicit_explicit_only_summary">Schakelt alleen codering in</string>
+    <string name="disable_banner_title">Schakel banner uit</string>
+    <string name="disable_feat_title">Schakel FUNCTIE uit</string>
+    <string name="disable_syst_title">Schakel SYST uit</string>
+    <string name="tls_limit_protocols_title">Beperk protocollen</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -193,7 +193,6 @@ na stronie https://github.com/ppareit/swiftp/issues .\n\n
     <string name="write_external_storage_old_android_version_summary">Na tych urządzeniach cały sklep jest dostępny przy użyciu hierarchii plików.</string>
 
     <string name="battery_saver_setting_title">Program oszczędzający baterię</string>
-    <string name="battery_saver_desc">UWAGA: *musisz* ręcznie zrestartować serwer po zmianie.</string>
     <string name="bs_high">WYSOKI</string>
     <string name="bs_low">NISKI</string>
     <string name="bs_deep">GŁĘBOKO</string>
@@ -203,4 +202,37 @@ na stronie https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Maksymalna liczba jednoczesnych połączeń</string>
     <string name="manage_anon_label">Zarządzaj anonimowo…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Porty…</string>
+    <string name="general_title">Ogólny…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Ulepszenia zabezpieczeń…</string>
+    <string name="port_number_label_data_low">Niski zakres numerów portów danych</string>
+    <string name="port_number_label_data_high">Wysoki zakres numerów portów danych</string>
+    <string name="port_number_label_implicit">Niejawny numer portu FTPS</string>
+    <string name="enable_tls">Włącz TLS</string>
+    <string name="enable_tls_implicit">Włącz niejawnie</string>
+    <string name="enable_ssl">Włącz protokół SSL</string>
+    <string name="disable_plain_port">Używaj tylko niejawnie</string>
+    <string name="disable_plain_not_explicit">Używaj tylko ukrytych i jawnych</string>
+    <string name="cert_keystore">Certyfikat: importuj magazyn kluczy (jks)</string>
+    <string name="cert_trust_store">Certyfikat: import zaufanego magazynu (bks)</string>
+    <string name="cert_pass">Certyfikat: hasło</string>
+    <string name="cert_show_pass">Certyfikat: pokaż hasło</string>
+    <string name="cert_use_client">Wymagaj certyfikatu klienta</string>
+    <string name="early_150_response">Obejście problemu z wcześniejszą odpowiedzią 150</string>
+    <string name="ip_list_title">Zezwalaj/odmawiaj adresów IP</string>
+    <string name="deny_until_allowed">Odmawiaj, dopóki nie zostanie to dozwolone</string>
+    <string name="manually_add_ip">Ręcznie dodaj adres IP</string>
+    <string name="deny_on_failed_logins">Odmów w przypadku 3 nieudanych logowań</string>
+    <string name="clear_unused_ips">Usuń nieużywane adresy IP</string>
+    <string name="implicit_only_summary">Wyłącza zwykły port</string>
+    <string name="implicit_explicit_only_summary">Włącza tylko szyfrowanie</string>
+    <string name="disable_banner_title">Wyłącz baner</string>
+    <string name="disable_feat_title">Wyłącz FEAT</string>
+    <string name="disable_syst_title">Wyłącz SYST</string>
+    <string name="tls_limit_protocols_title">Ogranicz protokoły</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -109,7 +109,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="app_theme">Тема...</string>
 
     <string name="battery_saver_setting_title">Экономия заряда батареи</string>
-    <string name="battery_saver_desc">ПРИМЕЧАНИЕ. После внесения изменений вы *должны* вручную перезапустить сервер.</string>
     <string name="bs_high">ВЫСОКИЙ</string>
     <string name="bs_low">НИЗКИЙ</string>
     <string name="bs_deep">ГЛУБОКИЙ</string>
@@ -119,4 +118,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Максимальное количество одновременных подключений</string>
     <string name="manage_anon_label">Управление анонимностью…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Порты…</string>
+    <string name="general_title">Общий…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Улучшения безопасности…</string>
+    <string name="port_number_label_data_low">Низкий диапазон номеров портов данных</string>
+    <string name="port_number_label_data_high">Диапазон номеров портов данных слишком высок</string>
+    <string name="port_number_label_implicit">Неявный номер порта FTPS</string>
+    <string name="enable_tls">Включить TLS</string>
+    <string name="enable_tls_implicit">Включить неявное</string>
+    <string name="enable_ssl">Включить SSL</string>
+    <string name="disable_plain_port">Используйте только неявное</string>
+    <string name="disable_plain_not_explicit">Используйте только неявное и явное</string>
+    <string name="cert_keystore">Сертификат: хранилище ключей импорта (jks)</string>
+    <string name="cert_trust_store">Сертификат: хранилище доверенных сертификатов импорта (bks)</string>
+    <string name="cert_pass">Сертификат: пароль</string>
+    <string name="cert_show_pass">Сертификат: показать пароль</string>
+    <string name="cert_use_client">Требовать сертификат клиента</string>
+    <string name="early_150_response">Обходной путь раннего ответа 150</string>
+    <string name="ip_list_title">Разрешить/запретить IP-адреса</string>
+    <string name="deny_until_allowed">Запретить, пока не разрешено</string>
+    <string name="manually_add_ip">Добавить IP вручную</string>
+    <string name="deny_on_failed_logins">Запретить 3 неудачных входа в систему</string>
+    <string name="clear_unused_ips">Очистить неиспользуемые IP-адреса</string>
+    <string name="implicit_only_summary">Отключает простой порт</string>
+    <string name="implicit_explicit_only_summary">Включает только шифрование</string>
+    <string name="disable_banner_title">Отключить баннер</string>
+    <string name="disable_feat_title">Отключить ФЕАТ</string>
+    <string name="disable_syst_title">Отключить систему</string>
+    <string name="tls_limit_protocols_title">Ограничительные протоколы</string>
 </resources>

--- a/app/src/main/res/values-sq/strings.xml
+++ b/app/src/main/res/values-sq/strings.xml
@@ -195,7 +195,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="write_external_storage_old_android_version_summary">Në këto pajisje, e gjithë dyqani është në dispozicion duke përdorur hierarkinë e skedarit.</string>
 
     <string name="battery_saver_setting_title">Kursuesi i baterisë</string>
-    <string name="battery_saver_desc">SHËNIM: *Duhet* të rinisni manualisht serverin pas ndryshimit.</string>
     <string name="bs_high">I LARTË</string>
     <string name="bs_low">I ULËT</string>
     <string name="bs_deep">THELLË</string>
@@ -205,4 +204,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Lidhjet maksimale të njëkohshme</string>
     <string name="manage_anon_label">Menaxho anonim…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Portet…</string>
+    <string name="general_title">Gjenerali…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Përmirësimet e sigurisë…</string>
+    <string name="port_number_label_data_low">Gama e numrit të portës së të dhënave është e ulët</string>
+    <string name="port_number_label_data_high">Gama e numrit të portës së të dhënave është e lartë</string>
+    <string name="port_number_label_implicit">Numri i portit të nënkuptuar FTPS</string>
+    <string name="enable_tls">Aktivizo TLS</string>
+    <string name="enable_tls_implicit">Aktivizo të nënkuptuar</string>
+    <string name="enable_ssl">Aktivizo SSL</string>
+    <string name="disable_plain_port">Përdorni vetëm të nënkuptuar</string>
+    <string name="disable_plain_not_explicit">Përdorni vetëm të nënkuptuar dhe të qartë</string>
+    <string name="cert_keystore">Certifikata: importo dyqan çelësash (jks)</string>
+    <string name="cert_trust_store">Certifikata: dyqani i besimit të importit (bks)</string>
+    <string name="cert_pass">Certifikata: fjalëkalimi</string>
+    <string name="cert_show_pass">Certifikata: tregoni fjalëkalimin</string>
+    <string name="cert_use_client">Kërkohet certifikata e klientit</string>
+    <string name="early_150_response">Zgjidhja e hershme e përgjigjes 150</string>
+    <string name="ip_list_title">Lejo/refuzo IP-të</string>
+    <string name="deny_until_allowed">Moho deri sa të lejohet</string>
+    <string name="manually_add_ip">Shtoni manualisht IP</string>
+    <string name="deny_on_failed_logins">Refuzoni 3 hyrje të dështuara</string>
+    <string name="clear_unused_ips">Pastro IP-të e papërdorura</string>
+    <string name="implicit_only_summary">Çaktivizon portin e thjeshtë</string>
+    <string name="implicit_explicit_only_summary">Aktivizon vetëm enkriptimin</string>
+    <string name="disable_banner_title">Çaktivizo bannerin</string>
+    <string name="disable_feat_title">Çaktivizo FEAT</string>
+    <string name="disable_syst_title">Çaktivizo SYST</string>
+    <string name="tls_limit_protocols_title">Limit protokollet</string>
 </resources>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -128,7 +128,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="app_theme">Тема...</string>
 
     <string name="battery_saver_setting_title">Уштеда батерије</string>
-    <string name="battery_saver_desc">НАПОМЕНА: *морате* ручно поново покренути сервер након промене.</string>
     <string name="bs_high">ХИГХ</string>
     <string name="bs_low">ЛОВ</string>
     <string name="bs_deep">ДУБОКО</string>
@@ -138,4 +137,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Максимално истовремене везе</string>
     <string name="manage_anon_label">Управљајте анонимно…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Луке…</string>
+    <string name="general_title">Генерал…</string>
+    <string name="ftps_title">ФТПС…</string>
+    <string name="security_section_title">Сигурносна побољшања…</string>
+    <string name="port_number_label_data_low">Низак опсег броја портова података</string>
+    <string name="port_number_label_data_high">Висок опсег броја портова података</string>
+    <string name="port_number_label_implicit">ФТПС имплицитни број порта</string>
+    <string name="enable_tls">Омогући ТЛС</string>
+    <string name="enable_tls_implicit">Омогући имплицитно</string>
+    <string name="enable_ssl">Омогући ССЛ</string>
+    <string name="disable_plain_port">Користите само имплицитно</string>
+    <string name="disable_plain_not_explicit">Користите само имплицитно и експлицитно</string>
+    <string name="cert_keystore">Сертификат: увоз кључева (јкс)</string>
+    <string name="cert_trust_store">Сертификат: увозна продавница поверења (бкс)</string>
+    <string name="cert_pass">Сертификат: лозинка</string>
+    <string name="cert_show_pass">Сертификат: прикажи лозинку</string>
+    <string name="cert_use_client">Захтевајте сертификат клијента</string>
+    <string name="early_150_response">Заобилазно решење за ране 150 одговора</string>
+    <string name="ip_list_title">Дозволи/одбиј ИП-ове</string>
+    <string name="deny_until_allowed">Одбити док се не дозволи</string>
+    <string name="manually_add_ip">Ручно додајте ИП</string>
+    <string name="deny_on_failed_logins">Одбиј на 3 неуспела пријављивања</string>
+    <string name="clear_unused_ips">Обришите неискоришћене ИП адресе</string>
+    <string name="implicit_only_summary">Онемогућава обичан порт</string>
+    <string name="implicit_explicit_only_summary">Омогућава само шифровање</string>
+    <string name="disable_banner_title">Онемогући банер</string>
+    <string name="disable_feat_title">Онемогући ФЕАТ</string>
+    <string name="disable_syst_title">Онемогући СИСТ</string>
+    <string name="tls_limit_protocols_title">Лимит протоколи</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -166,7 +166,6 @@ https://github.com/ppareit/swiftp/issues .\n\n
     <string name="write_external_storage_old_android_version_summary">На цих пристроях вся пам\'ять доступна за допомогою ієрархії файлів.</string>
 
     <string name="battery_saver_setting_title">Економія батареї</string>
-    <string name="battery_saver_desc">ПРИМІТКА. Ви *потрібно* вручну перезапустити сервер після зміни.</string>
     <string name="bs_high">ВИСОКА</string>
     <string name="bs_low">НИЗЬКИЙ</string>
     <string name="bs_deep">ГЛИБОКИЙ</string>
@@ -176,4 +175,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Максимальна кількість одночасних підключень</string>
     <string name="manage_anon_label">Керувати анонімно…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Порти…</string>
+    <string name="general_title">Загальні…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Покращення безпеки…</string>
+    <string name="port_number_label_data_low">Низький діапазон номерів портів даних</string>
+    <string name="port_number_label_data_high">Високий діапазон номерів портів даних</string>
+    <string name="port_number_label_implicit">Неявний номер порту FTPS</string>
+    <string name="enable_tls">Увімкнути TLS</string>
+    <string name="enable_tls_implicit">Увімкнути неявний</string>
+    <string name="enable_ssl">Увімкніть SSL</string>
+    <string name="disable_plain_port">Використовуйте лише неявні</string>
+    <string name="disable_plain_not_explicit">Використовуйте лише неявні та явні</string>
+    <string name="cert_keystore">Сертифікат: імпортувати сховище ключів (jks)</string>
+    <string name="cert_trust_store">Сертифікат: імпорт довіреного сховища (bks)</string>
+    <string name="cert_pass">Сертифікат: пароль</string>
+    <string name="cert_show_pass">Сертифікат: показати пароль</string>
+    <string name="cert_use_client">Вимагати сертифікат клієнта</string>
+    <string name="early_150_response">Обхідний шлях ранньої відповіді 150</string>
+    <string name="ip_list_title">Дозволити/заборонити IP-адреси</string>
+    <string name="deny_until_allowed">Відмовляти, поки не дозволено</string>
+    <string name="manually_add_ip">Додайте IP вручну</string>
+    <string name="deny_on_failed_logins">Заборонити 3 невдалих входу</string>
+    <string name="clear_unused_ips">Очистити невикористані IP-адреси</string>
+    <string name="implicit_only_summary">Відключає простий порт</string>
+    <string name="implicit_explicit_only_summary">Вмикає лише шифрування</string>
+    <string name="disable_banner_title">Вимкнути банер</string>
+    <string name="disable_feat_title">Вимкнути FEAT</string>
+    <string name="disable_syst_title">Вимкнути SYST</string>
+    <string name="tls_limit_protocols_title">Лімітні протоколи</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,7 +83,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建议。\n\n
     <string name="widget_name">FTP Server Widget</string>
 
     <string name="battery_saver_setting_title">省电</string>
-    <string name="battery_saver_desc">注意：更改后您*必须*手动重新启动服务器。</string>
     <string name="bs_high">高的</string>
     <string name="bs_low">低的</string>
     <string name="bs_deep">深的</string>
@@ -93,4 +92,37 @@ https://github.com/ppareit/swiftp/issues 提交您的建议。\n\n
 
     <string name="anon_max_conn">最大同时连接数</string>
     <string name="manage_anon_label">管理匿名…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">端口…</string>
+    <string name="general_title">常规…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">安全增强…</string>
+    <string name="port_number_label_data_low">数据端口号范围低</string>
+    <string name="port_number_label_data_high">数据端口号范围高</string>
+    <string name="port_number_label_implicit">FTPS 隐式端口号</string>
+    <string name="enable_tls">启用 TLS</string>
+    <string name="enable_tls_implicit">启用隐式</string>
+    <string name="enable_ssl">启用 SSL</string>
+    <string name="disable_plain_port">仅使用隐式</string>
+    <string name="disable_plain_not_explicit">仅使用隐式和显式</string>
+    <string name="cert_keystore">证书：导入密钥库 (jks)</string>
+    <string name="cert_trust_store">证书：导入信任库 (bks)</string>
+    <string name="cert_pass">证书：密码</string>
+    <string name="cert_show_pass">证书：显示密码</string>
+    <string name="cert_use_client">需要客户端证书</string>
+    <string name="early_150_response">早期 150 响应解决方法</string>
+    <string name="ip_list_title">允许/拒绝 IP</string>
+    <string name="deny_until_allowed">拒绝直到允许</string>
+    <string name="manually_add_ip">手动添加 IP</string>
+    <string name="deny_on_failed_logins">拒绝 3 次登录失败</string>
+    <string name="clear_unused_ips">清除未使用的 IP</string>
+    <string name="implicit_only_summary">禁用纯端口</string>
+    <string name="implicit_explicit_only_summary">仅启用加密</string>
+    <string name="disable_banner_title">禁用横幅</string>
+    <string name="disable_feat_title">禁用 FEAT</string>
+    <string name="disable_syst_title">禁用 SYST</string>
+    <string name="tls_limit_protocols_title">限制协议</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -183,7 +183,6 @@ https://github.com/ppareit/swiftp/issues 提交您的建議。\n\n
     <string name="write_external_storage_old_android_version_summary">在這些裝置上，可以使用檔案階層標準來使用所有存儲空間。</string>
 
     <string name="battery_saver_setting_title">省電</string>
-    <string name="battery_saver_desc">注意：更改後您*必須*手動重新啟動伺服器。</string>
     <string name="bs_high">高的</string>
     <string name="bs_low">低的</string>
     <string name="bs_deep">深的</string>
@@ -193,4 +192,37 @@ https://github.com/ppareit/swiftp/issues 提交您的建議。\n\n
 
     <string name="anon_max_conn">最大同時連線數</string>
     <string name="manage_anon_label">管理匿名…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">港口…</string>
+    <string name="general_title">一般的…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">安全增強…</string>
+    <string name="port_number_label_data_low">資料連接埠號碼範圍低</string>
+    <string name="port_number_label_data_high">資料連接埠號碼範圍高</string>
+    <string name="port_number_label_implicit">FTPS 隱式連接埠號</string>
+    <string name="enable_tls">啟用 TLS</string>
+    <string name="enable_tls_implicit">啟用隱式</string>
+    <string name="enable_ssl">啟用 SSL</string>
+    <string name="disable_plain_port">僅使用隱式</string>
+    <string name="disable_plain_not_explicit">僅使用隱式和顯式</string>
+    <string name="cert_keystore">憑證：導入金鑰庫（jks）</string>
+    <string name="cert_trust_store">憑證：匯入信任庫（bks）</string>
+    <string name="cert_pass">證書：密碼</string>
+    <string name="cert_show_pass">證書：顯示密碼</string>
+    <string name="cert_use_client">需要客戶端證書</string>
+    <string name="early_150_response">早期 150 響應解決方法</string>
+    <string name="ip_list_title">允許/拒絕 IP</string>
+    <string name="deny_until_allowed">拒絕直到允許為止</string>
+    <string name="manually_add_ip">手動新增IP</string>
+    <string name="deny_on_failed_logins">拒絕 3 次登入失敗</string>
+    <string name="clear_unused_ips">清除未使用的IP</string>
+    <string name="implicit_only_summary">禁用普通連接埠</string>
+    <string name="implicit_explicit_only_summary">僅啟用加密</string>
+    <string name="disable_banner_title">禁用橫幅</string>
+    <string name="disable_feat_title">禁用專長</string>
+    <string name="disable_syst_title">停用系統</string>
+    <string name="tls_limit_protocols_title">限制協議</string>
 </resources>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -25,6 +25,9 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
     <string name="show_password_default" translatable="false">false</string>
     <string name="allow_anonymous_default" translatable="false">false</string>
     <string name="portnumber_default" translatable="false">2121</string>
+    <string name="portnumber_default_implicit" translatable="false">2122</string>
+    <string name="portnumber_default_pasv_low" translatable="false">0</string>
+    <string name="portnumber_default_pasv_high" translatable="false">0</string>
     <string name="acceptwifi_default" translatable="false">true</string>
     <string name="wakelock_default" translatable="false">true</string>
     <string name="writeExternalStorage_default" translatable="false">true</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -211,4 +211,37 @@ https://github.com/ppareit/swiftp/issues .\n\n
 
     <string name="anon_max_conn">Max simultaneous connections</string>
     <string name="manage_anon_label">Manage anonymous…</string>
+
+    <string name="found_check">&#10004;</string>
+    <string name="found_check_green">&#9989;</string>
+    <string name="found_x">&#10007;</string>
+    <string name="ports_title">Ports…</string>
+    <string name="general_title">General…</string>
+    <string name="ftps_title">FTPS…</string>
+    <string name="security_section_title">Security enhancements…</string>
+    <string name="port_number_label_data_low">Data port number range low</string>
+    <string name="port_number_label_data_high">Data port number range high</string>
+    <string name="port_number_label_implicit">FTPS implicit port number</string>
+    <string name="enable_tls">Enable TLS</string>
+    <string name="enable_tls_implicit">Enable implicit</string>
+    <string name="enable_ssl">Enable SSL</string>
+    <string name="disable_plain_port">Use implicit only</string>
+    <string name="disable_plain_not_explicit">Use implicit and explicit only</string>
+    <string name="cert_keystore">Certificate: import keystore (jks)</string>
+    <string name="cert_trust_store">Certificate: import trust store (bks)</string>
+    <string name="cert_pass">Certificate: password</string>
+    <string name="cert_show_pass">Certificate: show password</string>
+    <string name="cert_use_client">Require client certificate</string>
+    <string name="early_150_response">Early 150 response workaround</string>
+    <string name="ip_list_title">Allow/deny IPs</string>
+    <string name="deny_until_allowed">Deny until allowed</string>
+    <string name="manually_add_ip">Manually add IP</string>
+    <string name="deny_on_failed_logins">Deny on 3 failed logins</string>
+    <string name="clear_unused_ips">Clear unused IPs</string>
+    <string name="implicit_only_summary">Disables plain port</string>
+    <string name="implicit_explicit_only_summary">Enables encryption only</string>
+    <string name="disable_banner_title">Disable banner</string>
+    <string name="disable_feat_title">Disable FEAT</string>
+    <string name="disable_syst_title">Disable SYST</string>
+    <string name="tls_limit_protocols_title">Limit protocols</string>
 </resources>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="sharedpref" file="encrypted_prefs"/>
+</full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+    <exclude domain="sharedpref" file="encrypted_prefs"/>
+</cloud-backup>
+</data-extraction-rules>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,54 +59,223 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
         </PreferenceScreen>
 
 
-        <PreferenceScreen
-            android:title="@string/advanced_settings_label">
-            <EditTextPreference
-                android:defaultValue="@string/portnumber_default"
-                android:key="portNum"
-                android:title="@string/port_number_label" />
+        <PreferenceScreen android:title="@string/advanced_settings_label"
+            android:key="preference_screen_advanced">
 
-            <CheckBoxPreference
-                android:defaultValue="@string/wakelock_default"
-                android:key="stayAwake"
-                android:title="@string/wakelock_label" />
+            <PreferenceCategory android:title="@string/ports_title">
 
-            <CheckBoxPreference
-                android:defaultValue="@string/writeExternalStorage_default"
-                android:key="writeExternalStorage"
-                android:title="@string/writeExternalStorage_label" />
+                <EditTextPreference
+                    android:defaultValue="@string/portnumber_default"
+                    android:key="portNum"
+                    android:inputType="number"
+                    android:title="@string/port_number_label" />
 
-            <CheckBoxPreference
-                android:defaultValue="@string/useScopedStorage_default"
-                android:key="useScopedStorage"
-                android:drawableLeft="@drawable/ic_shared_dir"
-                android:drawableStart="@drawable/ic_shared_dir"
-                android:title="@string/use_scoped_storage_label"
-                android:summary="@string/use_scope_storage_summary"
-                />
+                <EditTextPreference
+                    android:defaultValue="@string/portnumber_default_pasv_low"
+                    android:key="portRangePasvLow"
+                    android:inputType="number"
+                    android:title="@string/port_number_label_data_low" />
 
-            <ListPreference
-                android:defaultValue="0"
-                android:entries="@array/pref_list_battery_saver_titles"
-                android:entryValues="@array/pref_list_battery_saver_values"
-                android:key="battery_saver"
-                android:dialogTitle="@string/battery_saver_setting_title"
-                android:title="@string/battery_saver_setting_title"
-                android:summary="@string/battery_saver_desc"/>
+                <EditTextPreference
+                    android:defaultValue="@string/portnumber_default_pasv_high"
+                    android:key="portRangePasvHigh"
+                    android:inputType="number"
+                    android:title="@string/port_number_label_data_high" />
+
+                <EditTextPreference
+                    android:defaultValue="@string/portnumber_default_implicit"
+                    android:key="portNumImplicit"
+                    android:inputType="number"
+                    android:dependency="enableImplicitPort"
+                    android:title="@string/port_number_label_implicit" />
+
+            </PreferenceCategory>
+
+            <PreferenceCategory android:title="@string/general_title">
+
+                <CheckBoxPreference
+                    android:defaultValue="@string/wakelock_default"
+                    android:key="stayAwake"
+                    android:title="@string/wakelock_label" />
+
+                <CheckBoxPreference
+                    android:defaultValue="@string/writeExternalStorage_default"
+                    android:key="writeExternalStorage"
+                    android:title="@string/writeExternalStorage_label" />
+
+                <CheckBoxPreference
+                    android:defaultValue="@string/useScopedStorage_default"
+                    android:key="useScopedStorage"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:title="@string/use_scoped_storage_label"
+                    android:summary="@string/use_scope_storage_summary"
+                    />
+
+                <ListPreference
+                    android:defaultValue="0"
+                    android:entries="@array/pref_list_battery_saver_titles"
+                    android:entryValues="@array/pref_list_battery_saver_values"
+                    android:key="battery_saver"
+                    android:dialogTitle="@string/battery_saver_setting_title"
+                    android:title="@string/battery_saver_setting_title"
+                    android:summary="@string/battery_saver_desc"/>
+
+            </PreferenceCategory>
 
             <PreferenceCategory
                 android:key="settings"
                 android:title="@string/logging">
-            <CheckBoxPreference
-                android:defaultValue="@string/enableLogging_default"
-                android:key="enable_logging"
-                android:title="@string/enable_logging" />
+                <CheckBoxPreference
+                    android:defaultValue="@string/enableLogging_default"
+                    android:key="enable_logging"
+                    android:title="@string/enable_logging" />
 
-            <Preference
-                android:key="logs"
-                android:title="@string/manage_log_label" />
+                <Preference
+                    android:key="logs"
+                    android:title="@string/manage_log_label" />
 
             </PreferenceCategory>
+
+            <PreferenceCategory android:title="@string/ftps_title">
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="enableImplicitPort"
+                    android:title="@string/enable_tls_implicit" />
+
+                <!-- SSL not tested at all so leaving commented and fully disabled -->
+                <!-- <CheckBoxPreference
+                     android:defaultValue="false"
+                     android:drawableStart="@drawable/ic_shared_dir"
+                     android:drawableLeft="@drawable/ic_shared_dir"
+                     android:key="enableSsl"
+                     android:title="@string/enable_ssl" />-->
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="disablePlainPort"
+                    android:summary="@string/implicit_only_summary"
+                    android:title="@string/disable_plain_port" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="disablePlainNotExplicit"
+                    android:summary="@string/implicit_explicit_only_summary"
+                    android:title="@string/disable_plain_not_explicit" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="certKeyStore"
+                    android:title="@string/cert_keystore" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="certTrustStore"
+                    android:title="@string/cert_trust_store" />
+
+                <EditTextPreference
+                    android:defaultValue=""
+                    android:inputType="textPassword"
+                    android:key="certPassword"
+                    android:title="@string/cert_pass" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="certShowPassword"
+                    android:title="@string/cert_show_pass" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="useClientCert"
+                    android:title="@string/cert_use_client" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="early150Response"
+                    android:title="@string/early_150_response" />
+
+                <MultiSelectListPreference
+                    android:dialogTitle="@string/tls_limit_protocols_title"
+                    android:key="limitTLSProtocols"
+                    android:title="@string/tls_limit_protocols_title" />
+
+            </PreferenceCategory>
+
+            <PreferenceCategory android:title="@string/security_section_title">
+
+                <MultiSelectListPreference
+                    android:dialogTitle="@string/ip_list_title"
+                    android:key="ip_list"
+                    android:title="@string/ip_list_title" />
+
+                <EditTextPreference
+                    android:defaultValue=""
+                    android:inputType="text"
+                    android:key="manuallyAddIP"
+                    android:hint="000.111.0.*"
+                    android:title="@string/manually_add_ip" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="clearUnusedIPs"
+                    android:title="@string/clear_unused_ips" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="denyUntilAllowed"
+                    android:title="@string/deny_until_allowed" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="denyOnFailedLogins"
+                    android:title="@string/deny_on_failed_logins" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="disableBanner"
+                    android:title="@string/disable_banner_title" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="disableFeat"
+                    android:title="@string/disable_feat_title" />
+
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:drawableStart="@drawable/ic_shared_dir"
+                    android:drawableLeft="@drawable/ic_shared_dir"
+                    android:key="disableSyst"
+                    android:title="@string/disable_syst_title" />
+
+            </PreferenceCategory>
+
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
# Requirements: None

- All required pull requests are already merged in. Looks great.

- There's a lot of changes here that can be very subjective. I feel it looks great and it also works great. But, that's only what I think =)

- Tested against current master branch. Just noting some differences that affects how it builds and runs.

	- Current master has some Logging UI menu stuff not yet implemented.

	- Current master has new string values cs, but it isn't like the others, so am leaving this as not translated for that (and not added to it as well) as I don't know what's going on there. I can add a translated commit later if asked.

# Important info for this pull request

This is FTPS TLS and also things to use it in various ways like IPv6 for example. This is mostly why I'm keeping it all together as one pull request. Without any one thing, its less secure, not as useful, etc. All of it together makes up FTPS use. Also, I don't really feel like trying to tear it all apart but will if asked to.

There's quite a lot in this pull request. The following should give a lot of understanding with how it all works and how to use it. I'm including this info for all users and not all of it is here for pull request reasons :)

Beginners: are included the best I can throughout all info but... I won't do full step-by-step and do not explain every single thing possible. Internet can be searched so do that where you need it.

Quick list of things implemented, fixed, or improved in this pull request...

- FTPS TLS
  - Implicit
  - Explicit
  - Can require client certificate
  - Can force encryption only
  - And more

- Added commands
  - AUTH
  - EPSV
  - EPRT
  - PBSZ
  - PROT

- IPv6
  - Local Link
  - Global

- Data port range selection
  - Default full random
  - Limit to user choice

- IP Allow/deny list
  - Automatically adds all connected IPs
  - Can manually add IPs
  - Can manually add partial IPs using *

- Can deny on failed logins
  - Auto denies on 3 failed wrong user or password attempts
  - Override manually by using the list for allow/deny to bypass failure checks

- Can disable
  - Banner
  - FEAT
  - SYST

- All these things make up improved remote use of internet via router

*By default* TLS is disabled and you must enable it and provide certificates to use it. Info on how to do this is provided below.

This code is provided as is. Use at your own risk. I'm adding this because of increased possibility to use when open to internet. See risks further below.

**Do not use this for unlawful purposes.**


# Tests run

Even though the tests are all successful, it doesn't mean I still didn't miss something. I'd say post the issue but there's a lot of issues that are actually in the clients, networking, device, etc. You will find quite a few various issues you can run into in the info below and how to deal with those. If its a feature or is a minor problem of the code here, add it to the things not done list at the bottom. If there's something major, I will check in here and there, and look into fixing it if its something that can be fixed.

Lots of use tests during development.

Available for remote internet via router for 1-2 months now. Occasionally used fully remotely to success.

Final tests include:

Tests include Android 6, a few on Android 8, most on Android 14. Variety of pull request settings used to test them all further.

Can't do heavy testing on pure remote for unknown data connection timeout issue and inability to do auto testing here. But transfers, dir creation. movement, deletions, etc have all been successful with only non-code issues seen. Pure remote via wifi tested as working good but also can't run auto testing for this. Android 14 client to Swiftp on Android 8.

  - Non-code issue seen: When using data connection there are many timeouts (At least 90% of the time).
	
  - Diagnosed as: Most likely with this data connection or a networking issue of primary router.
	
  - Further data connection remote tests on this issue...

    - FileZilla Server + Windows OS and Android 14 client (FileZilla Server issue encountered)

    - Client on Android 8 to Swiftp on Android 9 (TLSv1.2 on both)..................................... same timeouts

    - Client on Android 8 to Swiftp on Android 9 (TLSv1.2 on both) but on plain connection............. same timeouts

    - Both client and Swiftp devices connected directly to primary router and not to sub equipment .... same timeouts

    - **_Android 14 client to Windows FTP Server FTPS ................................................... same timeouts (aka not a code issue)_**

- ### (Update) Remote data connection upload failure testing

  Client

    - Samsung Files:	Up to 20 files and dirs before failure
    - FX File Explorer: Up to 4k files and dirs before failure
    
    Result: Different client to be needed to decrease problems.
  ________

  Router

    - Router TCP timeouts set too low will cause failure at some point. For FX File Explorer, increase of router TCP timeouts allows 5k files to transfer up on remote data connection without failure.
    
    Result: If router TCP timeouts can be changed, increase them.
  ________

  What did not help

    - Removing or increasing code timeouts

    - Disabling code TcpNoDelay

    Result: Changes in Swiftp did not result in helping remote data connection. However, FTP client and the router TCP timeout values are the problem areas and dealing with those takes me from about twenty files and dirs before failure to over five thousand without any failure in tests so far in multiple tests. Issue is now resolved.

    Should also note that router firmware issues may also cause a problem. Previously tested on a router firmware issues to no improvement in other clients. That firmware problem has since been fixed.
  ________

The following tests are using transfer up, down, delete, and full final comparison with hash. WinSCP client command line. Scoped storage.

  - 9 clients simultaneous (to help stress test threading) to 3 users to 2 internal and 1 sd card locations. 4 clients on internal each: 649 files and 51 dirs at 2.6GB. 5 clients on sd card each: 5,531 files, 739 dirs, 65MB. FTPS explicit only. No failures or problems seen.

	- Android 14

  - 1 client to each of 2 internal and 1 sd card location using mixture of both FTPS implicit and explicit. 12k files, 2.5k dirs, at 3GB each full round of tests (one full round for each Swiftp user). All tests run continuously for hours with no failures or problems seen.

	- Android 14

	- Android 8

	- Android 6

	- Android 14 active

	- Android 14 IPv6 global local network

	- Android 14 IPv6 global local network active

	- Android 14 IPv6 link local address on local network

- Some manual transfer up, down, and manual comparison of transferred test stuff using FileZilla. Android 14.
	- non-FTPS issue seen: Known FileZilla multi connection double MKD command issue via scoped storage dirs. A fix to keep it from wrongly creating a 2nd duplicate dir is under testing.

- Plain (non-FTPS) connection with one extra full round of auto tests done but this has been in use up until now anyway with no problems. No regressions seen.

- Quick test using Android 14 with USB Ethernet adapter has been tested as working without any issues seen. It was noticeably very responsive. Also, testing showed it to be a solution to Android 14 connection sleeping issue https://github.com/ppareit/swiftp/pull/229#issuecomment-2273822578 and https://github.com/ppareit/swiftp/pull/229#issuecomment-2275611203

- Also quickly tested as working fine on Android 13 and 15.

The following tests are all java.io.File tests only to confirm that FTPS is not seeing anything unexpected from it (there should be no problem like this):

- java.io.File local. Using transfer up, down, delete, and full final comparison with hash. WinSCP client to Android 8. Mix of FTPS implicit and explicit to 2 internal locations full auto test round. Local network.
  - Non code issue was seen during sd card test: "getLocalInetAddress called and no connection"
  - Diagnosed as: The wifi AP dropped the device wifi. This wifi AP has that issue with this device.

- java.io.File using IPv6 local. Using transfer up, down, delete, and full final comparison with hash. WinSCP client to Android 8. Mix of FTPS implicit and explicit to 2 internal locations full auto test round. Local network.

- Java.io.File simulated remote based auto tests via public router IP on local network. Using transfer up, down, delete, and full final comparison with hash. WinSCP client to Android 8. FTPS explicit to 1 internal location with full auto test round. 
  - Needs active to be used. Shouldn't really do it this way anyway, and should probably use two logins, one for local and one for remote.

- Java.io.File local plain (non-FTPS) regression check. Using transfer up, down, delete, and full final comparison with hash. WinSCP client to Android 8. FTPS explicit to 1 internal location with full auto test round.


# Some quick notes

- Added three settings to disable banner, FEAT, and SYST. Some clients won't like commands disabled. For example with SYST, Samsung Files will throw an error "Unknown error: vfs.provider/list-children.error" on that one. Its fine with FEAT and banner disabled.

- Use the same password for all certificate stuff. Decided on this as the keystore and pkcs12 files require the same cert password to work correctly. Will be broken when clients try to connect from BoringSSL deciding only there and then that its not okay. Could change this as I implemented two password inputs and saved it to the side but not wanting to deal with it any further.

- Added auto restart of the FTP server if its already running while user changes setting's that breaks the server. There was already one setting with a force disable and this improves that one as well. There's too many breaking settings now, so it is necessary. All alternatives are not nearly as enjoyable.

- Added "Require client certificate" setting. This requires any connecting client to be using the matching pkcs12 file. WinSCP for example offers this feature. All other clients without it or with a non-matching one will receive an error upon connecting and be refused. Offers increased security. Android 7+ only due to Java's own official code problems there.

- Certificate import and password have multi styled check marks. The marks change when checks test it. Depending on the device, it could be x (not found), red check marks (found but not working), and white check marks (ready for use)... or it will be... x, white, and green on newer devices. I felt the need to do this because clients can fail on handshake where the certificates are used, and so in combination, would be extra difficult for users to understand. This makes it much easier (and for me too). This most likely won't help you any if you supply a wrongly created cert. Its a check to make sure the certs are there, can be read, and the password for them is working.

- (This is a code thing) Keystore is using Bouncy Castle and has file extension of jks but needs to use "BKS" instead of "JKS" although the file is still jks. Confused? lol.

- Keystore password is required. Keystore (the jks file) is required.

- Trust store (the bks file) isn't required as Android can use a default one but... did not test long enough to know how well it works without it. Because it was seen working without it, users can decide not to import the trust cert if wanting to try. When using trust cert, the password is required.

- Android's TLS versions are by default OS version specific. Eg Android 8 is TLS v1.2, Android 10+ is v1.3. This is *not* something I'm going to try to change via code.

- Tested using Let's Encrypt cert but doesn't really do anything over any self-signed one so it won't improve functionality. And public use (public here being anyone on the internet can connect) I'm not dealing with, where it would be of use. So, not typing up how to do it. If its something you want to do, you can search and figure it out with some doing.

- CmdPASV getHostAddress() is technically wrong for remote access but all tests show that clients deal with it just fine by falling back to IP used before PASV is reached (the IP that the client is already using lol). Passive and active and everything everywhere is seen as working. Someone more picky would have to do it as I'm not changing it.

- Default passive ports still use current way of default 0 (zero basically means large random port range) until manually changed in advanced settings. Can also return to default 0 by setting the new advanced settings for both ports low and high to 0 or empty. Using 0 is recommended. Failure to open ports can occur when the range is too restricted. Random doesn't keep track of anything and can randomly pick badly.

- For default TLS implicit port, am just going to 1 digit above plain port. I don't care at all. It works and its just a working default.

- Certificate imports ingest the files to app private cache directory. This keeps the certs private while allowing the app to have easy access to the files. However, if the app cache is cleared manually by user, uninstall, or automatically by device on low space, then the certs may be lost and TLS connections will fail. These files should be protected. I didn't like any alternatives.

- Certificate file imports probably won't get automatically backed up by Google Backup. Haven't looked into how other backup solutions may deal with it or any further into this.

- Certificate password is protected by encrypted pref and automatic backup is expected to never back that up. Am protecting it this way at a minimum, and therefore also scrub the unencrypted password input pref on save.

- Certificate password can be shown to the user by the setting to show it and this will also add it back to the unencrypted password pref as well so the user can work with it fully visible. However, this lowers security as the password is then easily visible to nefarious apps that can read the screen, and has a larger decrypted footprint. But, it was quick to implement and is still expected to be "app private", so am giving this to the user. Its very useful at times too.

- IPs added to the fail list... I feel its only good to not wipe or remove from this list too easily. So, you must manually allow an IP, to remove it from the fail list. This will keep unwanted IPs still on the fail list while not having allowed IPs get onto the fail list. You really shouldn't find yourself needing anything but this anyway.

- Active TLS IPv4 and IPv6 use is implemented for both implicit and explicit and both local and remote. Quick tested as working (browsing, transfer up and down, dir creation, deletion) on local and remote connections so I know it works. Caveat: only made sure it was working. Did not run full testing on this. Probably 99.9% of people never need to use this and I have never needed it... but it works. Some clients have problems and it may fail with those.

- Added TLS implicit port (when the port is enabled) *to* the notification and to the line in the app at the server toggle button.

- Class PreferenceFragment's onCreate() is now really lengthy. Am leaving it this way for this pull request but it would be nice if the preferences were split out to methods.


### Risks. Warning and caution when opening to the internet or running on hostile networks.

- Effort has been taken to improve security with this pull request. At the same time, various settings and choices do seriously degrade security when open to the internet or make security ineffective. Unknown issues or flaws if present could seriously degrade security or make it ineffective.

- The safest thing is always to _never_ open something to the internet or on a hostile network. If you're concerned or have a bad feeling then don't risk it. Its that simple.

- Has not received 3rd party security audit penetration testing to find flaws. That simply means there's no proof or guarantees of its security.

- TLS itself can have security flaws. As such, TLS has/had security flaws with handshake, TCP related flaws, and whatever else. Android's Conscrypt or BoringSSL/OpenSSL could contain flaws. The code of this pull request could have flaws. Your router could have flaws. And probably other things could too. Users may make flaws. All things involved or related can contain security flaws.

- I wish for you to be safe.

### Improvements you can make for security now that the warnings are done...

- Just a note on domains and IPs. Domain names to router IP will increase bots such as DDNS. Domains are public and mapped so public facing domains can be found by bots. If you can, avoid domains. Regardless of the choice, not using a domain is good for lowering bot activity and internet visibility.

- There are good bots. There are bad bots. Some good ones have public searchable info and others do not. You can find out if a connected IP is a bot by putting the connected IP into a whois lookup and researching it further. Connected IPs can be viewed at the time of this pull request via the "Logging" pull request and also via the "Allow/deny list" feature included in this pull request.

- Make sure you have a router that is still receiving security updates and that it is fully updated. Make sure you do not have bad settings or choices in use. Make sure it has no known security issues involving port forwarding, etc such as multiple ASUS routers have recently seen.

- You can also find websites that will port check your router from the internet side to see if it has any problems in that way. If any bad problems are found, look into that before doing anything else and make sure its good.

- Instead of all ports using port forwarding, you can use port triggering to dynamically open all the data connection ports instead. Port forwarding keeps these ports open all the time and that's not necessary.

- If your router offers adding a time schedule to port forwarding, you can add that to close the port for some amount of hours so that its not open when it will never be used.

- If your router has a feature to accept only selected wanted IPs and block all unwanted IPs when opening ports, enable and use it for more safety as it can stop unwanted IPs from even getting into the network from the opened port. It could also be that the router may offer it for IPv6 and not IPv4 or vice vesa. This blocking feature may be under the firewall section in the router - using that to block all IPs and having a highly specific allow IP range before the block of eg 12.0.0.1-12.255.255.255 would allow a variance of IPs if dynamic, or can use a specific IP if the client's IP doesn't change.

- Clients using EPRT, the ports to use are selected *by the client*. For remote internet use here, it would require router port opening to be adjusted accordingly. It would be better to use port triggering in this instance. For local, nothing needs to be done.

- Also, keep an eye on logs.

Directly in the app the following can be used to enhance security:

- Don't use anonymous. Bots can far more easily attempt to get in from there.

- Don't use port 2121 as its a known ftp associated port. An example port that bots may be less likely to try is 2122.

- Enabling encryption only by using the new advanced settings "TLS implicit only" or "TLS implicit/explicit only".

- Use setting to limit the protocols to only TLSv1.3 if possible or to both TLSv1.3 and TLSv1.2 at worst (or if your device is max TLSv1.2, then limit to only allow TLSv1.2). These two are the only officially recommended choices in 2024. Nothing older is considered secure. There is nothing newer than TLSv1.3 at this time and is currently the latest and the most secure. With the limit, a client trying an older protocol will be denied.

- Using the IP "Deny until allowed" feature included with this pull request as another line of defense.

- Using the pkcs12 certificate file with clients that can and enabling the new advanced setting "Require client certificate" to put it into action. An example client is WinSCP. Requires Android 7+.


# Certificates

Am not including certificate files as they require a hardcoded password and that would have to be considered compromised. You will have to create one. You can use the following sample to make the required files or find your own way (there's many ways and configurations so a simple working sample will have to do that produces something good enough to use):

Sample creation of self-signed certificate for TLS/SSL that works:

  - I did this on Linux via OpenSSL where its readily available. If on another OS like Windows, you may need to spend time getting OpenSSL. FYI, if you take a shortcut, you may far more likely just obtain a non-working certificate. Am providing some helpful hints to successfully get a working cert but nothing more. The internet has no shortage of tutorials and stuff on this (it has too much actually). The below lines can be copy pasted for working certificates.

  - If on Windows, you can alternatively install any VM or install Windows WSL and install any Linux distro inside Windows that way such as Ubuntu, Debian, Fedora. or many others. Openssl and keytool would then be easily available. I may not ever provide step-by-step for any of this and you can search the internet on how to do it. Unfortunately, it can be complicated, especially to get speed in a VM, you may need to go into the BIOS (the hardware and BIOS version have to support virtualization) or make other complicated changes in Windows should it not be immediately working fast.

  o You first need to download a bouncy castle provider file. I'm using "bcprov-jdk18on-1.78.1.jar" at this time. This file is found under JDK 1.8 and later: https://www.bouncycastle.org/download/bouncy-castle-java/

- Put the provider into the dir where you will make the certs to make it easy. You can then simply copy paste and be done without adjusting paths in the below lines. You can create all the required certs really fast by doing this.

`openssl req -x509 -sha256 -days 365 -newkey rsa:2048 -keyout k.key -out p.pem`

- There's no required way to fill out the form to have it work here. If its open to the internet, you may not want to use personal info but do want to make it look like its from you in a way understood by whoever uses it.

`openssl pkcs12 -export -inkey k.key -in p.pem -out p.p12`

`keytool -importkeystore -srckeystore p.p12 -srcstoretype PKCS12 -destkeystore storejks.jks -deststoretype BKS -providerclass org.bouncycastle.jce.provider.BouncyCastleProvider -providerpath bcprov-jdk18on-1.78.1.jar`

- Requires password to be used. Password must be the same as the pkcs12 file.

`keytool -importcert -v -trustcacerts -file p.pem -alias IntermediateCA -keystore storebks.bks -provider org.bouncycastle.jce.provider.BouncyCastleProvider -providerpath bcprov-jdk18on-1.78.1.jar -storetype BKS`

- Requires password to be used. Password must be the same as the pkcs12 file as the pull request currently does not accept two passwords to remove a point of bad user confusion.

- Type yes to trust

 o You can now move the jks and bks files to the Android device then import them into the app. You can then delete your two cert files for extra security after import as the app will have copied them into app private storage and be using them from there.

 o The bks file is technically optional. Android will provide a default trust store without it but I've only quickly tested this with not enough testing so I don't know if there's problems that show up with more use.

 o The pkcs12 file can be used with clients that support client certificates. Enable advanced setting "Require client certificate" to put it into action. Requires Android 7+.

 o And you need to also supply the password in the app, because without it, TLS would fail to work from having no access to the key store.

 o You will have to recreate the certs before the days are up. I use 365 days in the above example. Certs are recommended to max out at one year for safety. Let's Encrypt certs as an example are only 90 days. But, if you only use FTPS locally on your own network without internet then you should be able to safely set many years. The choice is yours in the end. If the certs expire before you update them, all clients will fail to connect.


# Connection setup examples

 ### IPv4 remote example...

 o Setup Swiftp ports to use in the app's advanced settings.
	
  - eg 2122 implicit port and 2123 low to 2150 high

 o Router ports need to be forwarded to device IP example:

  - Log into router interface > port forwarding
  - Use IP of device running Swiftp
  - Either
  - Forward all TCP ports eg 2122-2150. (Worst)
  - Use port forwarding for the explicit/plain and/or implicit port eg 2122 & use port triggering for the low & high ports eg 2123-2150. (Best)
  - Save

FileZilla v3.67.0+ client example (all other clients configure mostly same)

  - Use the router/modem internet IP as assigned by ISP (if dynamic server then need a separate means of updating that when it changes)
  - Swiftp port to use eg 2122
  - Select implicit tls
  - Swiftp user to use
  - Pass of that user
  - Best to increase timeouts due to LIST and other things taking time (how much heavily depends)
  - Save/connect

  ### IPv6 example...

  o Notes on IPv6 address use

  - Global address: you'll want to find the device's least changing address. There can be two or three global addresses assigned to one Android device. At least one changes very fast while another sticks around. The router may not show this address although it can be spliced together manually from it. The location without doing that can be a little different but should be found within Android wifi settings. Android 14 may be found in the connection info of the connected ssid > view more. Android 8 may be found in wifi's more menu > advanced > view more. You can use the global address with any client compatible with it.

  - Local link address: the local link address can be used in any client compatible with it.

  - The global address also contains the router's IPv6 public IP address, whereas the local does not. Thus, the global can also instantly connect to the device remotely via the internet. Instead, the local address is similar to using an IPv4 address and requires two parts. That is something to keep in mind for security reasons. Both still need an incoming port opened when using remotely. One other difference is that a router may force an IPv6 address of the client device as well when opening a port so that only it can connect or others added, which is a nice security improvement. But, not all clients support IPv6 addresses even in 2024 and it does need a stable IPv6 address to be useful.

  - If you look around on the internet, you'll probably find topics on Android and getting stable IPv6 addresses via something it might never support: IPv6 stateful mode. That's bad info and will get you down the wrong track lol. The above is how you can deal with that. Just find the stable address from the device's connection info. You can do that by trying them or taking a screen shot. If all is good with your router and device then there *will* be something stable (unstable ones may change within some hours or within some days). I see a stable address on both Android 8 and 14 and it continues to work when connecting. Its been working for over a month so far since I began testing stable IPv6 address use here.

  - Android 14 (may affect other Android OS versions) IPv6 requires battery saver HIGH. Battery saver LOW and DEEP are fine for IPv4 but not IPv6. This is because IPv6 sockets sleep (or whatever Android does here) when on LOW or DEEP. Thus, if you use LOW or DEEP with IPv6, idle will cause connection failure after a short time of the screen being off (Android sleeping), until the screen is turned back on. To avoid this, either use IPv4 or use battery saver HIGH.

 ### Local IPv6 example (tested using FileZilla)

   - You'll need the device with Swiftp IPv6 global address obtained from wherever such as the router interface or device wifi info.
   - Setup Swiftp ports to use in the app's advanced settings.
		eg 21430 implicit port and 21431 low to 21450 high
   - FileZilla v3.67.0+ client example (all other clients configure mostly same)
   - Use the [IPv6 global address] or [IPv6 link local address] including the []s
   - Swiftp connection port to use eg 21430
   - Select implicit tls
   - Swiftp user to use
   - Pass of that user
   - Best to increase timeouts due to LIST and other things taking time (how much heavily depends)
   - Save/connect

  ### Remote IPv6 example (tested as working from an Android client)

  - Obtain the local device with Swiftp IPv6 global address from the router or device networking info screen
  - Obtain the remote device IPv6 global address
  - Swiftp setup the ports to use eg 50001 explicit/plain port and 50002 low to 50030 high

  Router...
  - Open IPv6 pinhole, port forwarding, and/or port triggering. Your router may contain a special section with this in comparison to IPv4.
  o Either
    - Forward all TCP ports eg 50001-50030. (Worst)
    - Use port forwarding for the explicit/plain and/or implicit port eg 50001 & use port triggering for the low & high ports eg 50002-50030. (Best)
  - External host is remote device IPv6 global address
  - Internal host is local device IPv6 global address
  - Save

  Client...
  - Use the local device [IPv6 global address] including the []s
  - Swiftp connection port to use eg 50001
  - Select explicit/implicit tls
  - Swiftp user to use
  - Pass of that user
  - Best to increase client timeouts if possible
  - Save/connect

  ### 2nd Remote IPv6 example using Total Commander (Android) client

  - Obtain the stable IPv6 global address from the Android device running Swiftp
  - Obtain the remote device IPv6 global address using internet IPv6 test website
  - Swiftp setup the ports to use eg 60212 explicit/plain port and 21200 low to 21300 high

  Router...
  - Open IPv6 pinhole
    - External host: remote device IPv6 address
    - Internal host: set to local device
    - Destination ports: 60212
  - Setup port triggering for data ports
    - Trigger ports: 60212 (source) > any (destination)
    - Ports to open: any (source) > 21200 - 21300 (destination)
  - Save

  Client...
  - Server name: [stable local device's global IPv6 address]:60212
  - Enable SSL encrypt
  - Put in username and pass of the Switftp user to use
  - Use passive
  - Enable IPv6 (although it works even if you don't so whatever)
  - Save/connect

  ### Port forwarding example...

  - eg explicit/plain port at 2121, low port 50050, high port 50100.
  - IP 000.111.0.1
	
  - TCP 2121
  - Alternative view: TCP > Source Any > Destination 2121

  ### Port triggering example...

  Works for both IPv4 and IPv6.

  - eg explicit/plain port at 2121, low port 50050, high port 50100.

  o Outgoing ports
   - TCP 2121 -> Any
	
  o Incoming ports
   - TCP Any -> 50050 - 50100

# Here's how some other clients tested

### TLSv1.3 resumption note:

- Don't really know if resumption is working with TLSv1.3 or not. According to this an issue on git for conscrypt/issues/985 it is working under the hood. But, supposedly there's no way for me to check that as they don't give a way and because of how v1.3 works. The v1.3 documentation appears to also say it can decline resumption under various situations on its own so that too could be something.

- On top of this, FileZilla (FileZilla tested at v.3.67.0) appears to feel that there's no need to force TLS versions in the client... WinSCP can force itself to v1.2 and appears to have working resumption that way in the exact same setup. WinSCP fresh client open at v1.3 "Main TLS session ID not reused, will not try again". Fresh client open at v1.2 "Session ID reused". 

- Might even be related to an OpenSSL issue like this one that's been going for a good amount of years on git openssl/issues/11378 .

- Could be something I didn't see and continue to not see in the code. Tried many things though and nothing worked.

- Its complicated with a lot of possibilities so did not fully look into this.

* Removed git links as seeing this in reference on other github projects is ridiculous, and even more so, the reference can't be removed. Oh well lol.


### "Advanced settings -> Early 150 response workaround"

  - A bunch of clients (eg WinSCP by default*, all Android clients) at this time require this to be enabled to function with TLS.

  - When its disabled, you will know, as you will see failure during one or more of LIST, MLSD, MLST, NLST, STOR, or RETR.
	  The data connection TLS handshake timeout happens after roughly 30 seconds with some clients ending things before then.

  - All clients I've tested work with it enabled in every way so you can leave it enabled all the time and forget about it.

  - *In WinSCP, can use its raw setting instead "FtpTransferActiveImmediately2=on" that enables the late 150 there.



### All Files Access on Android note

Android has no firewall or anything else. Apps can nefariously upload your personal files in the background without you even knowing to put it simply. If you use All Files Access, you must implicitly trust the app fully including all 3rd party code the app uses that can be out of a dev's knowledge with ALL of your files, even in the background and even when the app looks like its not running.

- It is possible to install a firewall on devices that have OEM Unlock but the firewall is more of block all or block none. The firewall can also possibly log files so one can see what is happening but that's after the fact. Android officially supposedly might add a similar kind of log to future OS version at some point.

If you use an app without this, the app can only access files in allowed dirs by default such as Downloads. It must be granted access to most dirs, by you the user, to access other files. This is why its better for security and for you.

https://source.android.com/docs/core/storage/scoped

In the end, you take the risk you want. You can of course monitor app stats to see time and amount of network used or other things. But, that's only going to get you so far, and it can also consume your life. There are advanced things that can help but I'm not getting into that. For most people, those advanced things are out.



### FileZilla v3.67.1 (Windows OS)

   - Everything works. As I use it above in the examples, not adding anything further here.


### WinSCP v6.3.3 (Windows OS)

  (TLS implicit IPv4)

   - Tested as working for both remote and local

   - (requires either WinSCP's "FtpTransferActiveImmediately2=on" or this pull request's "Advanced settings -> Early 150 response workaround")

   - Tested with v1.3 Android 14 device and v1.2 Android 8 device

  (TLS explicit IPv4)

   - Working for both remote and local

   - (requires either WinSCP's "FtpTransferActiveImmediately2=on" or this pull request's "Advanced settings -> Early 150 response workaround")

   - Tested with v1.3 Android 14 device and v1.2 Android 8 device

  (TLS implicit/explicit IPv6)

  - Same as IPv4. IPv6 is fully working with both local link and global addresses.



### Samsung Files v15.0.04.5 | Network Storage Manager v12.3.00.8 (Android OS)

   - It has the duplication problem, and requires all files access but it is provided by the device manufacturer and is a built in OS app, so ALL FILES ACCESS here is less concerning. Those two things are still something to think about.

Notice: Samsung Network Storage is has some bad working code, but, router firmware/software can also make it appear worse. As in my case, the one part of the current official router software in 2025 for my router causes this client to fail to send more than 1 file at a time while others can. I found this to be true upon spending more time working to downgrade router software, and getting part of it downgraded. After that version, I had noticed some problems start. If you have router problems impacting this client, it can be difficult to diagnose/solve. Not all routers allow downgrading.

  (TLS implicit/explicit IPv4)

   - Implicit does not work here. This client can't get through the TLS handshake

   - Explicit working for both remote and local

   - Active does not work here (only passive works)

   - At this time, the client does weird duplicated responses. The end result is its working and is usable, despite the weirdness. Its a client issue as it tested the same with other FTP servers. Samsung Network Storage Manager needs an update to fix it.

   - (requires "Advanced settings -> Early 150 response workaround")

   - Tested with v1.3 Android 14 device.

  (TLS implicit/explicit IPv6)

   - This client does not appear to support IPv6 addresses at this time.



### FX File Explorer v9.0.1.2 (Android OS)

   - I wouldn't recommend this client because it requires ALL FILES ACCESS so is worse for security.

   (TLS implicit/explicit IPv4)

   - Working for both remote and local

   - (requires "Advanced settings -> Early 150 response workaround")

   - Tested with v1.3 Android 14 device and v1.2 Android 8 device



### Total Commander FTP v2.47 (Android OS)

   - I've listed this but wouldn't actually recommend this client. Its UI is horrible (to copy a file to ftp: swipe left, long press on file, scroll down, copy, swipe right, long press on ftp folder, paste - this should be simplified) and it requires ALL FILES ACCESS so is worse for security. Has a really short data connection timeout. Complains about EPSV PASV during IPv6 use although server doesn't see this and it might be a result of what the client tries because of the timeout (this does not appear to be a code problem here as EPSV works fine and PASV isn't being called (this pull request code rightfully blocks PASV from even being used as EPSV and PASV should never be combined with the same client connection).

   (TLS implicit/explicit IPv4)

   - Tested off network remote as working via domain name and direct IP

   - Tested local as working via local IP

   - Tested domain passive on local network as not working with this client. Tested as not a wrong IP return issue. However, active tested as working.

   - (requires "Advanced settings -> Early 150 response workaround")

   - Tested with v1.3 Android 14 device

   (TLS implicit/explicit IPv6)

   - Total Commander doesn't have use of link local addresses

   - Global addresses can be used to work locally

   - IPv6 remote testing briefly as working.

   - (requires "Advanced settings -> Early 150 response workaround")



### Super FTP v1.0.5 (Android OS)

   -  I've listed this but wouldn't actually recommend this client at all. It works but can only transfer one FILE at a time so its highly limited in ability (uses Android's singular file picker so it doesn't have its own code for recursively dealing with dirs). However, it doesn't require all files access so its good in a way.

  (TLS explicit IPv4 remote public IP)

   - It works.

   - (requires "Advanced settings -> Early 150 response workaround")

  (TLS implicit/explicit IPv6)

   - (requires "Advanced settings -> Early 150 response workaround")

   - IPv6 Link local not supported in this client.

   - IPv6 Global does work here.

 Nothing else with this client has been tested.



### Solid Explorer (Android OS)

   - Not recommended for security as it requires ALL FILES ACCESS.

   - Does not appear to support IPv6.

   - Nothing else tested.



### EX File Manager (Android OS)

   - Not recommended for security as it requires ALL FILES ACCESS.

   - Supports IPv6 global.

   - Nothing else tested.



# Things not done

Don't expect me to do these or anything else. Its ~possible~ that I will in time if someone else doesn't but am also not saying that I'm going to do anything further here. It is most likely that I'm done with it. _Edit: I'm fully exiting programming, dev stuff so there won't be anything further from me._

 - Try generating a certificate directly inside the app and see if and how well it works here.

 - Further security enhancements when open to the internet or hostile networks if there's anything else to add. Maybe something like, notifying on the device (instead of only in logs), of new _connected to the socket_ IPs could be nice and keeping the notification code deduplicated so that there's no additional maintenance. May be other things not yet thought of.

 - Improvement to random for limited data connection port count as java.util.Random sometimes picks a number just used and will then definitely fail when it otherwise didn't have to fail at that moment. Could keep track of the ports. Could try again if socket fails on a port.

 - More settings: adjust timeout value, possibly limit ciphers, user selectable fail count of perhaps 1, 3, 5, 7, 10, 15, 25, 50. And more stuff.

 - Further implement the new FTP commands as they're currently done only to a working minimum.

 - Anything I missed from the rfc docs.

 - SSL (maybe never). Currently this setting is commented out as its untested. SSL is considered unsafe and should not be used today. TLS is its replacement.
