### PR TITLE
Fix connection wake locks still being set after battery saver is changed away from LOW

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsService.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsService.java
@@ -272,9 +272,12 @@ public class FsService extends Service implements Runnable {
             // @TODO: when using ethernet, is it needed to take wifi lock?
             takeWifiLock();
             takeWakeLock();
+            useConnWakeLocks = false;
         } else if (batterySaver == 1) {
             useConnWakeLocks = true;
             initializeConnWakeLocks();
+        } else {
+            useConnWakeLocks = false;
         }
 
         // A socket is open now, so the FTP server is started, notify rest of world


### PR DESCRIPTION
Switching from LOW, I missed disabling the one boolean. So, it was continuing to run the connection wake locks after that where they shouldn't be used (unless the app was forced stopped).