### PR TITLE
Updated UI for Pref and Frag to newer androidx

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,7 +51,8 @@ dependencies {
     implementation 'com.twofortyfouram:android-plugin-client-sdk-for-locale:4.0.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.jetbrains:annotations:23.0.0'
-    implementation 'androidx.work:work-runtime:2.9.0'
+    implementation 'androidx.work:work-runtime:2.9.1'
+    implementation 'androidx.preference:preference:1.2.1'
 }
 
 android {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
         <activity
             android:name="be.ppareit.swiftp.gui.MainActivity"
+            android:configChanges="screenSize|orientation"
             android:theme="@style/AppThemeDark"
             android:exported="true">
             <intent-filter>
@@ -72,6 +73,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
         <activity
             android:name=".gui.ManageUsersActivity"
+            android:configChanges="screenSize|orientation"
             android:parentActivityName=".gui.MainActivity"
             android:theme="@style/AppThemeDark" />
 

--- a/app/src/main/java/be/ppareit/swiftp/gui/MainActivity.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/MainActivity.java
@@ -79,8 +79,8 @@ public class MainActivity extends AppCompatActivity {
             ad.show();
         }
 
-        getFragmentManager().beginTransaction()
-                .replace(android.R.id.content, new PreferenceFragment())
+        getSupportFragmentManager().beginTransaction()
+                .replace(android.R.id.content, new PreferenceFragment(), null)
                 .commit();
     }
 

--- a/app/src/main/java/be/ppareit/swiftp/gui/ManageUsersActivity.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/ManageUsersActivity.java
@@ -12,7 +12,7 @@ public class ManageUsersActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         setTheme(FsSettings.getTheme());
         super.onCreate(savedInstanceState);
-        getFragmentManager().beginTransaction()
+        getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, UserListFragment.newInstance())
                 .commit();
     }

--- a/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/UserEditFragment.java
@@ -1,13 +1,13 @@
 package be.ppareit.swiftp.gui;
 
 import android.app.Activity;
-import android.app.Fragment;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/be/ppareit/swiftp/gui/UserListFragment.java
+++ b/app/src/main/java/be/ppareit/swiftp/gui/UserListFragment.java
@@ -1,13 +1,15 @@
 package be.ppareit.swiftp.gui;
 
 import android.app.AlertDialog;
-import android.app.Fragment;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Parcelable;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -68,7 +70,7 @@ public class UserListFragment extends Fragment {
             }
             refreshUserList();
         });
-        getActivity().getFragmentManager().beginTransaction()
+        getActivity().getSupportFragmentManager().beginTransaction()
                 .replace(android.R.id.content, editFragment)
                 .addToBackStack("default")
                 .setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,63 +18,78 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:key="preference_screen">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:key="preference_screen"
+    app:iconSpaceReserved="false">
 
     <SwitchPreference
         android:defaultValue="false"
         android:key="running_switch"
         android:summary="@string/running_summary_stopped"
-        android:title="@string/running_label" />
+        android:title="@string/running_label"
+        app:iconSpaceReserved="false" />
     <Preference
         android:key="market_version"
         android:summary="@string/market_version_summary"
-        android:title="@string/market_version_label" />
+        android:title="@string/market_version_label"
+        app:iconSpaceReserved="false" />
 
     <PreferenceCategory
         android:key="settings"
-        android:title="@string/settings_label">
+        android:title="@string/settings_label"
+        app:iconSpaceReserved="false">
 
         <Preference
             android:key="manage_users"
-            android:title="@string/manage_users_label" />
+            android:title="@string/manage_users_label"
+            app:iconSpaceReserved="false" />
 
         <Preference
             android:key="manage_anon"
-            android:title="@string/manage_anon_label" />
+            android:title="@string/manage_anon_label"
+            app:iconSpaceReserved="false"/>
 
         <PreferenceScreen
             android:key="appearance_screen"
-            android:title="@string/gui_settings_label">
+            android:title="@string/gui_settings_label"
+            app:iconSpaceReserved="false">
             <ListPreference
                 android:defaultValue="0"
                 android:entries="@array/pref_list_themes"
                 android:entryValues="@array/pref_list_themes_values"
                 android:key="theme"
-                android:title="@string/app_theme" />
+                android:title="@string/app_theme"
+                app:iconSpaceReserved="false" />
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="show_notification_icon_preference"
                 android:summary="@string/show_notification_icon_summary"
-                android:title="@string/show_notification_icon" />
+                android:title="@string/show_notification_icon"
+                app:iconSpaceReserved="false" />
         </PreferenceScreen>
 
 
         <PreferenceScreen
-            android:title="@string/advanced_settings_label">
+            android:key="preference_screen_advanced"
+            android:title="@string/advanced_settings_label"
+            app:iconSpaceReserved="false" >
             <EditTextPreference
                 android:defaultValue="@string/portnumber_default"
                 android:key="portNum"
-                android:title="@string/port_number_label" />
+                android:title="@string/port_number_label"
+                app:iconSpaceReserved="false" />
 
             <CheckBoxPreference
                 android:defaultValue="@string/wakelock_default"
                 android:key="stayAwake"
-                android:title="@string/wakelock_label" />
+                android:title="@string/wakelock_label"
+                app:iconSpaceReserved="false" />
 
             <CheckBoxPreference
                 android:defaultValue="@string/writeExternalStorage_default"
                 android:key="writeExternalStorage"
-                android:title="@string/writeExternalStorage_label" />
+                android:title="@string/writeExternalStorage_label"
+                app:iconSpaceReserved="false" />
 
             <CheckBoxPreference
                 android:defaultValue="@string/useScopedStorage_default"
@@ -83,7 +98,7 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
                 android:drawableStart="@drawable/ic_shared_dir"
                 android:title="@string/use_scoped_storage_label"
                 android:summary="@string/use_scope_storage_summary"
-                />
+                app:iconSpaceReserved="false" />
 
             <ListPreference
                 android:defaultValue="0"
@@ -92,19 +107,23 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
                 android:key="battery_saver"
                 android:dialogTitle="@string/battery_saver_setting_title"
                 android:title="@string/battery_saver_setting_title"
-                android:summary="@string/battery_saver_desc"/>
+                android:summary="@string/battery_saver_desc"
+                app:iconSpaceReserved="false" />
 
             <PreferenceCategory
                 android:key="settings"
-                android:title="@string/logging">
+                android:title="@string/logging"
+                app:iconSpaceReserved="false" >
             <CheckBoxPreference
                 android:defaultValue="@string/enableLogging_default"
                 android:key="enable_logging"
-                android:title="@string/enable_logging" />
+                android:title="@string/enable_logging"
+                app:iconSpaceReserved="false" />
 
             <Preference
                 android:key="logs"
-                android:title="@string/manage_log_label" />
+                android:title="@string/manage_log_label"
+                app:iconSpaceReserved="false" />
 
             </PreferenceCategory>
         </PreferenceScreen>
@@ -113,13 +132,16 @@ along with SwiFTP.  If not, see <http://www.gnu.org/licenses/>.
 
     <PreferenceCategory
         android:key="extra_category"
-        android:title="@string/extra_label">
+        android:title="@string/extra_label"
+        app:iconSpaceReserved="false" >
         <Preference
             android:key="help"
-            android:title="@string/help_label" />
+            android:title="@string/help_label"
+            app:iconSpaceReserved="false" />
         <Preference
             android:key="about"
-            android:title="@string/about_label" />
+            android:title="@string/about_label"
+            app:iconSpaceReserved="false"/>
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
o Updated UI for Pref and Frag to newer androidx to remove a big chunk of deprecated warnings. 

  - Of course there are other ways this can be done, but this is done with minimal changes, and clears out many deprecations and warnings.

## Required

  Nothing. This can be applied _without_ the FTPS pull request in the event that you do not want FTPS merged in.
  - A separate pull request will patch the FTPS code to be compatible. That way you can do whatever :)

## Fixes

  - https://github.com/ppareit/swiftp/issues/236

## Important notes

  - Only issue seen: Android 6 and 8 doesn't show the tap animation for the inner screen such as on Advanced Settings. It shows the long press animation but not tap. Android 14 shows the tap so its an issue with the support, compat, or androidx side of things. Really, just a minor issue. Everything else works great. Can workaround this if desired and add some tap animation but may not be identical.

  - To keep the same, had to wrap all prefs in null checks, as the new stuff doesn't see the rest now when fragment is switched to showing an inner pref screen due to inner pref screen changes in androidx. This is why I didn't want to adjust this to not include the FTPS pull request or adjust the FTPS pull request to this.

  - Manifest: size & orientation added to fix orientation issues on some sub screens where there was a problem.

  - iconSpaceReserved use in pref xml to fix the new large indentation spacing issue reserved for icons.

  - Updated to the current latest versions of all implementation's in build.gradle along with the androidx changes there. Think this fixed a build issue on androidx changes but didn't recheck it. No problems seen on any device so its good to go anyway.

  - popBackStack() used with theme switch to fix a back press issue that happens after the change without it.

## Tests

  - Fairly well tested all parts of the UI on each test device.

  - Tested as working on Android 14, 8, 6.

  - Tested dirty install.

  - Tested clean install on Android 14, 6.

  - Also good on Android 13 and 15.

  - Full testing of orientation changes to make sure its working properly on all screens, menus, Activities, and Fragments. Includes text editing, settings screens, etc so that user can move away to another app and move back to make adjustments without loss.

  - Full testing of back button use to make sure its working properly on all screens, menus, Activities, and Fragments.

  - Tested with two themes to make sure no problems were hidden there.