### PR TITLE
Fix anonymous crash on empty max connections

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/FsSettings.java
+++ b/app/src/main/java/be/ppareit/swiftp/FsSettings.java
@@ -206,6 +206,7 @@ public class FsSettings {
 
     public static int getAnonMaxConNumber() {
         String s = sp.getString("anon_max", "1");
+        if (s.isEmpty()) s = "1";
         int i = Integer.parseInt(s);
         Log.v(TAG, "Using anon max connections: " + i);
         return i;


### PR DESCRIPTION
Fixes issue https://github.com/ppareit/swiftp/issues/255

Don't allow app to crash from empty max connection.