### PR TITLE
Fix pref name for enabling scoped storage in Util so its the same as in PreferenceFragment

### DIFF
--- a/app/src/main/java/be/ppareit/swiftp/Util.java
+++ b/app/src/main/java/be/ppareit/swiftp/Util.java
@@ -119,7 +119,7 @@ abstract public class Util {
     public static boolean useScopedStorage() {
         if (useScoped != -1) return useScoped == 1; // gets used a lot so speed it up a little
         if (sp == null) sp = PreferenceManager.getDefaultSharedPreferences(App.getAppContext());
-        final boolean choice = sp.getBoolean("AllowNewScopedStorage", false);
+        final boolean choice = sp.getBoolean("UseScopedStorage", false);
         useScoped = choice ? 1 : 0;
         return choice;
     }


### PR DESCRIPTION
It accidentally became different during changes.

Fixes:

- https://github.com/ppareit/swiftp/issues/260